### PR TITLE
Fix dashboard auth and module path

### DIFF
--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.1-pre.1",
+  "version": "2.1.0-pre.1",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.0.6-pre.10",
+  "version": "2.1-pre.1",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/www/js/features/boiler.js
+++ b/custom_components/oig_cloud/www/js/features/boiler.js
@@ -69,7 +69,9 @@ async function loadBasicBoilerData() {
         }
 
         // Načíst profily
-        const profilesResp = await fetch(`/api/oig_cloud/${entryId}/boiler_profile`);
+        const profilesResp = await fetchWithAuth(`/api/oig_cloud/${entryId}/boiler_profile`, {
+            credentials: 'same-origin'
+        });
         if (profilesResp.ok) {
             const data = await profilesResp.json();
             boilerState.profiles = data.profiles || {};
@@ -78,7 +80,9 @@ async function loadBasicBoilerData() {
         }
 
         // Načíst plán
-        const planResp = await fetch(`/api/oig_cloud/${entryId}/boiler_plan`);
+        const planResp = await fetchWithAuth(`/api/oig_cloud/${entryId}/boiler_plan`, {
+            credentials: 'same-origin'
+        });
         if (planResp.ok) {
             boilerState.plan = await planResp.json();
             console.log('🔥 [Boiler] Plan loaded');

--- a/custom_components/oig_cloud/www/js/features/pricing.js
+++ b/custom_components/oig_cloud/www/js/features/pricing.js
@@ -2275,8 +2275,12 @@ async function fetchTimelineFromAPI(plan, boxId) {
     const timelineUrl = `/api/oig_cloud/battery_forecast/${boxId}/timeline?type=active`;
     const fetchStart = performance.now();
     console.log(`[Pricing] Fetching ${plan} timeline from API...`);
-    const response = await fetch(timelineUrl);
+    const response = await fetchWithAuth(timelineUrl, { credentials: 'same-origin' });
     if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
+            console.warn(`[Pricing] Unauthorized, skipping ${plan} timeline fetch`);
+            return [];
+        }
         throw new Error(`HTTP ${response.status}`);
     }
     const data = await response.json();

--- a/custom_components/oig_cloud/www/js/features/timeline.js
+++ b/custom_components/oig_cloud/www/js/features/timeline.js
@@ -172,7 +172,7 @@ function renderTodayPlanTile(tileSummary) {
         console.log('[Today Plan Tile] Loading module...');
         const script = document.createElement('script');
         script.type = 'module';
-        script.src = '/local/oig_cloud/www/modules/today-plan-tile.js';
+        script.src = 'modules/today-plan-tile.js';
         script.onload = () => {
             console.log('[Today Plan Tile] Module loaded, rendering...');
             initTodayPlanTile(container, tileSummary);


### PR DESCRIPTION
## Summary
- use authenticated fetch for OIG API calls in dashboard features
- load today-plan tile module from static path
- bump manifest version to 2.1-pre.1

## Testing
- not run (prod-only fix)
