### PR TITLE
Bump manifest version to 2.1.3

### DIFF
--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.1.1",
+  "version": "2.1.3",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary\n- bump manifest version to 2.1.3 so dashboard cache bust uses correct version\n\n## Testing\n- not run (version bump only)