### PR TITLE
Bump to 2.1.5 + planner final price alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Pricing tab loading overlay stuck on refresh.
+- Planner spot price timeline now uses the same final 15-minute price calculation as the current spot price sensor.
 - CHMU warning badge styling regressions.
 - Battery health tile overflow and spacing issues.
 - Planner badge update and mode label normalization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Timeline dialog: plan toggle switches between live Hybrid control and Autonomy preview dataset.
 - Analytics tile action: “Autonomní plán” opens the timeline dialog pre-filtered to the Autonomy plan.
 
+## [2.1.5] - 2026-01-16
+
+### Fixed
+
+- Planner spot price timeline now uses the same final 15-minute price calculation as the current spot price sensor.
+
 ## [2.1.4] - 2026-01-16
 
 ### Added
@@ -32,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Pricing tab loading overlay stuck on refresh.
-- Planner spot price timeline now uses the same final 15-minute price calculation as the current spot price sensor.
 - CHMU warning badge styling regressions.
 - Battery health tile overflow and spacing issues.
 - Planner badge update and mode label normalization.
@@ -236,7 +241,8 @@ If you use multiple devices, update automations/service calls to include `device
 - Service calls for mode control.
 - Statistics tracking.
 
-[Unreleased]: https://github.com/psimsa/oig_cloud/compare/v2.1.4...HEAD
+[Unreleased]: https://github.com/psimsa/oig_cloud/compare/v2.1.5...HEAD
+[2.1.5]: https://github.com/psimsa/oig_cloud/compare/v2.1.4...v2.1.5
 [2.1.4]: https://github.com/psimsa/oig_cloud/compare/v2.1.3...v2.1.4
 [2.0.6-pre.3]: https://github.com/psimsa/oig_cloud/compare/v2.0.6-pre.2...v2.0.6-pre.3
 [2.0.6-pre.2]: https://github.com/psimsa/oig_cloud/compare/v2.0.4...v2.0.6-pre.2

--- a/custom_components/oig_cloud/battery_forecast/data/pricing.py
+++ b/custom_components/oig_cloud/battery_forecast/data/pricing.py
@@ -146,6 +146,21 @@ def _find_entity(component: Any, sensor_id: str) -> Optional[Any]:
     return None
 
 
+def _get_price_sensor_entity(sensor: Any, *, price_type: str) -> Optional[Any]:
+    """Return the spot/export price sensor entity if available."""
+    hass = sensor._hass
+    if not hass:
+        return None
+
+    if price_type == "export":
+        sensor_id = f"sensor.oig_{sensor._box_id}_export_price_current_15min"
+    else:
+        sensor_id = f"sensor.oig_{sensor._box_id}_spot_price_current_15min"
+
+    component = _get_sensor_component(hass)
+    return _find_entity(component, sensor_id)
+
+
 def _derive_export_prices(
     spot_prices_dict: Dict[str, Any], config: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -210,13 +225,25 @@ async def get_spot_price_timeline(sensor: Any) -> List[Dict[str, Any]]:
         _LOGGER.warning("No prices15m_czk_kwh in spot price data")
         return []
 
+    price_sensor = _get_price_sensor_entity(sensor, price_type="spot")
+    sensor_price_fn = None
+    if price_sensor is not None:
+        sensor_price_fn = getattr(price_sensor, "_calculate_interval_price", None)
+        if not callable(sensor_price_fn):
+            sensor_price_fn = None
+
     computed_prices: Dict[str, Any] = {}
     for timestamp_str, raw_spot_price in raw_prices_dict.items():
         try:
             target_datetime = datetime.fromisoformat(timestamp_str)
-            computed_prices[timestamp_str] = calculate_final_spot_price(
-                sensor, raw_spot_price, target_datetime
-            )
+            if sensor_price_fn is not None:
+                computed_prices[timestamp_str] = sensor_price_fn(
+                    raw_spot_price, target_datetime
+                )
+            else:
+                computed_prices[timestamp_str] = calculate_final_spot_price(
+                    sensor, raw_spot_price, target_datetime
+                )
         except ValueError:
             _LOGGER.warning("Invalid timestamp in spot prices: %s", timestamp_str)
             continue

--- a/custom_components/oig_cloud/battery_forecast/data/pricing.py
+++ b/custom_components/oig_cloud/battery_forecast/data/pricing.py
@@ -122,12 +122,15 @@ def _get_export_config(sensor: Any) -> Dict[str, Any]:
 
 
 def _get_sensor_component(hass: Any) -> Optional[Any]:
-    if not hass or not isinstance(hass.data, dict):
+    if not hass:
         return None
-    entity_components = hass.data.get("entity_components")
+    hass_data = getattr(hass, "data", None)
+    if not isinstance(hass_data, dict):
+        return None
+    entity_components = hass_data.get("entity_components")
     if isinstance(entity_components, dict) and entity_components.get("sensor"):
         return entity_components.get("sensor")
-    return hass.data.get("sensor")
+    return hass_data.get("sensor")
 
 
 def _find_entity(component: Any, sensor_id: str) -> Optional[Any]:

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.1.4",
+  "version": "2.1.5",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary\n- Use the same final 15-minute price calculation as the current spot price sensor when building the planner timeline.\n- Guard price sensor lookup in tests without hass.data.\n- Bump version to 2.1.5 with changelog entry.\n\n## Testing\n- Not run locally (CI).