### PR TITLE
Bump 2.1.7: UPS mode mapping + stats backfill fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,9 @@
     "python.linting.flake8Enabled": false,
     "python.linting.mypyEnabled": true,
     "python.formatting.provider": "black",
-    "chatgpt.openOnStartup": true
+    "chatgpt.openOnStartup": true,
+    "sonarlint.connectedMode.project": {
+      "connectionId": "http-localhost-9001-",
+      "projectKey": "oig_cloud"
+    }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.7] - 2026-01-22
+
 ### Added
 
 - Battery planner wizard options: selector for Hybrid / Hybrid+Autonomy preview profiles + cheap-window and DP tuning fields (EN/CZ translations).
@@ -16,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Timeline dialog: plan toggle switches between live Hybrid control and Autonomy preview dataset.
 - Analytics tile action: “Autonomní plán” opens the timeline dialog pre-filtered to the Autonomy plan.
+
+### Fixed
+
+- Grid charging plan now maps UPS mode labels consistently in precomputed detail tabs.
+- Battery health statistics backfill includes discharge sensor and avoids noisy missing-data warnings.
 
 ## [2.1.6] - 2026-01-20
 

--- a/custom_components/oig_cloud/battery_forecast/presentation/precompute.py
+++ b/custom_components/oig_cloud/battery_forecast/presentation/precompute.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 from homeassistant.util import dt as dt_util
 
 from . import detail_tabs as detail_tabs_module
+from ..types import CBB_MODE_NAMES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +31,9 @@ async def precompute_ui_data(sensor: Any) -> None:
             detail_tabs, unified_cost_tile, timeline
         )
 
-        await sensor._precomputed_store.async_save(precomputed_data)  # pylint: disable=protected-access
+        await sensor._precomputed_store.async_save(
+            precomputed_data
+        )  # pylint: disable=protected-access
         sensor._last_precompute_hash = (
             sensor._data_hash
         )  # pylint: disable=protected-access
@@ -81,7 +84,9 @@ def _has_precomputed_store(sensor: Any) -> bool:
 
 async def _build_detail_tabs(sensor: Any) -> Dict[str, Any]:
     try:
-        return await detail_tabs_module.build_detail_tabs(sensor, plan="active")
+        return await detail_tabs_module.build_detail_tabs(
+            sensor, plan="active", mode_names=CBB_MODE_NAMES
+        )
     except Exception as err:
         _LOGGER.error("Failed to build detail_tabs: %s", err, exc_info=True)
         return {}
@@ -121,7 +126,9 @@ def _should_skip_precompute(sensor: Any, now: Any, force: bool) -> bool:
     if not sensor._last_precompute_at:  # pylint: disable=protected-access
         return False
     last_precompute = sensor._last_precompute_at  # pylint: disable=protected-access
-    if now - last_precompute < sensor._precompute_interval:  # pylint: disable=protected-access
+    if (
+        now - last_precompute < sensor._precompute_interval
+    ):  # pylint: disable=protected-access
         _LOGGER.debug(
             "[Precompute] Skipping (last run %ss ago)",
             (now - last_precompute).total_seconds(),

--- a/custom_components/oig_cloud/battery_forecast/sensors/grid_charging_sensor.py
+++ b/custom_components/oig_cloud/battery_forecast/sensors/grid_charging_sensor.py
@@ -148,9 +148,7 @@ class OigCloudGridChargingPlanSensor(CoordinatorEntity, SensorEntity):
                 detail_tabs.get("today", {}),
                 current_time,
             )
-            ups_blocks.extend(
-                _collect_tomorrow_blocks(detail_tabs.get("tomorrow", {}))
-            )
+            ups_blocks.extend(_collect_tomorrow_blocks(detail_tabs.get("tomorrow", {})))
 
             _LOGGER.debug(
                 "[GridChargingPlan] Found %s active/future UPS blocks (today + tomorrow)",
@@ -308,7 +306,9 @@ class OigCloudGridChargingPlanSensor(CoordinatorEntity, SensorEntity):
         return "off"
 
     @staticmethod
-    def _get_sorted_charging_blocks(charging_intervals: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _get_sorted_charging_blocks(
+        charging_intervals: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
         return sorted(
             charging_intervals,
             key=lambda b: (0 if b.get("day") == "today" else 1, b.get("time_from", "")),
@@ -533,9 +533,7 @@ def _collect_today_blocks(
             continue
 
         cost_key = "cost_historical" if status == "completed" else "cost_planned"
-        ups_blocks.append(
-            _build_ups_block(block, "today", status, cost_key, end_time)
-        )
+        ups_blocks.append(_build_ups_block(block, "today", status, cost_key, end_time))
     return ups_blocks
 
 
@@ -551,7 +549,16 @@ def _collect_tomorrow_blocks(tomorrow: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 def _is_home_ups_mode(*modes: str) -> bool:
-    return any(HOME_UPS_LABEL in (mode or "") for mode in modes)
+    """Check if any of the modes is HOME UPS (handles both 'HOME UPS' and 'Mode 3' formats)."""
+    for mode in modes:
+        if mode:
+            # Check for standard format
+            if HOME_UPS_LABEL in mode:
+                return True
+            # Fallback for legacy "Mode 3" format
+            if mode == "Mode 3":
+                return True
+    return False
 
 
 def _build_ups_block(

--- a/custom_components/oig_cloud/battery_forecast/sensors/recommended_sensor.py
+++ b/custom_components/oig_cloud/battery_forecast/sensors/recommended_sensor.py
@@ -23,6 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 HOME_1_LABEL = "Home 1"
 HOME_2_LABEL = "Home 2"
 HOME_3_LABEL = "Home 3"
+# Minimum interval between mode changes in recommended sensor.
+# Must match MIN_MODE_DURATION for HOME UPS (2 intervals = 30 min).
 MIN_RECOMMENDED_INTERVAL_MINUTES = 30
 MODE_LABEL_HOME_UPS = "Home UPS"
 
@@ -75,7 +77,9 @@ def _build_precomputed_payload(precomputed: Dict[str, Any]) -> Optional[Dict[str
     timeline = precomputed.get("timeline") or precomputed.get("timeline_hybrid")
     if not isinstance(timeline, list) or not timeline:
         return None
-    detail_tabs = precomputed.get("detail_tabs") or precomputed.get("detail_tabs_hybrid")
+    detail_tabs = precomputed.get("detail_tabs") or precomputed.get(
+        "detail_tabs_hybrid"
+    )
     return {
         "timeline_data": timeline,
         "calculation_time": precomputed.get("last_update"),
@@ -217,7 +221,9 @@ class OigCloudPlannerRecommendedModeSensor(
         mode_label = self._normalize_mode_label(
             planned.get("mode_name"), planned.get("mode")
         )
-        mode_code = planned.get("mode") if isinstance(planned.get("mode"), int) else None
+        mode_code = (
+            planned.get("mode") if isinstance(planned.get("mode"), int) else None
+        )
         return mode_label, mode_code
 
     def _mode_from_interval(  # pragma: no cover
@@ -226,7 +232,9 @@ class OigCloudPlannerRecommendedModeSensor(
         mode_label = self._normalize_mode_label(
             interval.get("mode_name"), interval.get("mode")
         )
-        mode_code = interval.get("mode") if isinstance(interval.get("mode"), int) else None
+        mode_code = (
+            interval.get("mode") if isinstance(interval.get("mode"), int) else None
+        )
         return mode_label, mode_code
 
     def _parse_interval_start(
@@ -303,7 +311,12 @@ class OigCloudPlannerRecommendedModeSensor(
         if current_idx is not None:
             return current_idx, current_start, current_mode, current_mode_code
 
-        return closest_idx, closest_start, closest_mode, closest_mode_code  # pragma: no cover
+        return (
+            closest_idx,
+            closest_start,
+            closest_mode,
+            closest_mode_code,
+        )  # pragma: no cover
 
     def _interval_mode(
         self, item: Dict[str, Any], *, planned: bool
@@ -373,7 +386,9 @@ class OigCloudPlannerRecommendedModeSensor(
 
     @staticmethod
     def _interval_after_min_gap(start: datetime, current_start: datetime) -> bool:
-        return start >= current_start + timedelta(minutes=MIN_RECOMMENDED_INTERVAL_MINUTES)
+        return start >= current_start + timedelta(
+            minutes=MIN_RECOMMENDED_INTERVAL_MINUTES
+        )
 
     def _get_auto_switch_lead_seconds(
         self, from_mode: Optional[str], to_mode: Optional[str]
@@ -549,9 +564,7 @@ class OigCloudPlannerRecommendedModeSensor(
         }
         return json.dumps(payload, sort_keys=True, default=str)
 
-    def _extract_payload_intervals(
-        self, payload: Dict[str, Any]
-    ) -> tuple[
+    def _extract_payload_intervals(self, payload: Dict[str, Any]) -> tuple[
         Optional[list[Dict[str, Any]]],
         Optional[str],
         Any,
@@ -594,9 +607,7 @@ class OigCloudPlannerRecommendedModeSensor(
             return dt_obj.tzinfo
         return None
 
-    def _tzinfo_from_timeline(
-        self, timeline: Any
-    ) -> Optional[datetime.tzinfo]:
+    def _tzinfo_from_timeline(self, timeline: Any) -> Optional[datetime.tzinfo]:
         if not isinstance(timeline, list):
             return None
         for item in timeline:
@@ -618,9 +629,7 @@ class OigCloudPlannerRecommendedModeSensor(
         if not planned_detail:
             return [], False
         planned_only = [
-            item
-            for item in detail_intervals
-            if self._interval_has_planned_mode(item)
+            item for item in detail_intervals if self._interval_has_planned_mode(item)
         ]
         return planned_only, True
 
@@ -651,7 +660,9 @@ class OigCloudPlannerRecommendedModeSensor(
             )
             if current_idx is None and detail_intervals:  # pragma: no cover
                 fallback = detail_intervals[0]
-                fallback_mode, fallback_code = self._planned_mode_from_interval(fallback)
+                fallback_mode, fallback_code = self._planned_mode_from_interval(
+                    fallback
+                )
                 fallback_start = self._parse_interval_time(
                     fallback.get("time"),
                     detail_date,

--- a/custom_components/oig_cloud/entities/battery_health_sensor.py
+++ b/custom_components/oig_cloud/entities/battery_health_sensor.py
@@ -243,7 +243,7 @@ class BatteryHealthTracker:
             self._hass,
             start_time,
             end_time,
-            {soc_sensor, charge_sensor},
+            {soc_sensor, charge_sensor, discharge_sensor},
             "day",
             None,
             {"mean", "max", "sum", "state"},
@@ -258,7 +258,11 @@ class BatteryHealthTracker:
         )
 
         if not soc_points or not charge_points:
-            _LOGGER.warning("Statistics backfill missing data")
+            _LOGGER.debug(
+                "Statistics backfill missing data (soc=%s, charge=%s)",
+                bool(soc_points),
+                bool(charge_points),
+            )
             return []
         if not discharge_points:
             _LOGGER.warning("Statistics backfill missing discharge data")

--- a/custom_components/oig_cloud/entities/battery_health_sensor.py
+++ b/custom_components/oig_cloud/entities/battery_health_sensor.py
@@ -121,7 +121,9 @@ class BatteryHealthTracker:
         except Exception as e:
             _LOGGER.error(f"Error saving to storage: {e}")
 
-    async def analyze_last_10_days(self) -> List[CapacityMeasurement]:  # pragma: no cover
+    async def analyze_last_10_days(
+        self,
+    ) -> List[CapacityMeasurement]:  # pragma: no cover
         """
         Analyzovat posledních 10 dní a najít čisté nabíjecí cykly.
 
@@ -214,7 +216,9 @@ class BatteryHealthTracker:
             _LOGGER.error(f"Error analyzing history: {e}", exc_info=True)
             return []
 
-    async def backfill_from_statistics(self) -> List[CapacityMeasurement]:  # pragma: no cover
+    async def backfill_from_statistics(
+        self,
+    ) -> List[CapacityMeasurement]:  # pragma: no cover
         """Backfill starších dat z recorder statistics."""
         if self._stats_backfill_until is not None:
             return []
@@ -303,8 +307,9 @@ class BatteryHealthTracker:
         discharge_energy = None
         if discharge_start is not None and discharge_end is not None:
             discharge_energy = discharge_end - discharge_start
-        if discharge_energy is not None and discharge_energy > self._max_discharge_threshold(
-            charge_energy
+        if (
+            discharge_energy is not None
+            and discharge_energy > self._max_discharge_threshold(charge_energy)
         ):
             _LOGGER.debug(
                 "Interval rejected: discharge during charge (%.0f Wh)%s",
@@ -365,7 +370,9 @@ class BatteryHealthTracker:
         new_measurements.append(measurement)
         return True
 
-    def _find_monotonic_charging_intervals(self, soc_states: List) -> List[tuple]:  # pragma: no cover
+    def _find_monotonic_charging_intervals(
+        self, soc_states: List
+    ) -> List[tuple]:  # pragma: no cover
         """
         Najít intervaly kde SoC MONOTÓNNĚ ROSTE (nikdy neklesne) o ≥50%.
 
@@ -496,7 +503,9 @@ class BatteryHealthTracker:
         return sorted(points, key=lambda x: x[0])
 
     @staticmethod
-    def _parse_stat_time(item: Dict[str, Any]) -> Optional[datetime]:  # pragma: no cover
+    def _parse_stat_time(
+        item: Dict[str, Any],
+    ) -> Optional[datetime]:  # pragma: no cover
         value = item.get("start") or item.get("start_time")
         if value is None:
             return None
@@ -509,12 +518,16 @@ class BatteryHealthTracker:
         return None
 
     @staticmethod
-    def _nearest_value(points: List[tuple], target_time: datetime) -> Optional[float]:  # pragma: no cover
+    def _nearest_value(
+        points: List[tuple], target_time: datetime
+    ) -> Optional[float]:  # pragma: no cover
         if not points:
             return None
         return min(points, key=lambda p: abs((p[0] - target_time).total_seconds()))[1]
 
-    def _find_monotonic_intervals_from_points(self, points: List[tuple]) -> List[tuple]:  # pragma: no cover
+    def _find_monotonic_intervals_from_points(
+        self, points: List[tuple]
+    ) -> List[tuple]:  # pragma: no cover
         intervals: List[tuple] = []
         if not points:
             return intervals
@@ -592,8 +605,9 @@ class BatteryHealthTracker:
             discharge_end = self._get_value_at_time(discharge_states, end_time)
             if discharge_start is not None and discharge_end is not None:
                 discharge_energy = discharge_end - discharge_start
-        if discharge_energy is not None and discharge_energy > self._max_discharge_threshold(
-            charge_energy
+        if (
+            discharge_energy is not None
+            and discharge_energy > self._max_discharge_threshold(charge_energy)
         ):
             _LOGGER.debug(
                 "Interval rejected: discharge during charge (%.0f Wh)%s",
@@ -812,15 +826,21 @@ class BatteryHealthTracker:
 
         return self._get_percentile_capacity(80, window=20)
 
-    def _get_percentile_soh(self, percentile: int, window: int = 20) -> Optional[float]:  # pragma: no cover
+    def _get_percentile_soh(
+        self, percentile: int, window: int = 20
+    ) -> Optional[float]:  # pragma: no cover
         values = self._get_recent_values("soh", window)
         return _percentile(values, percentile)
 
-    def _get_percentile_capacity(self, percentile: int, window: int = 20) -> Optional[float]:  # pragma: no cover
+    def _get_percentile_capacity(
+        self, percentile: int, window: int = 20
+    ) -> Optional[float]:  # pragma: no cover
         values = self._get_recent_values("capacity", window)
         return _percentile(values, percentile)
 
-    def _get_recent_values(self, kind: str, window: int) -> List[float]:  # pragma: no cover
+    def _get_recent_values(
+        self, kind: str, window: int
+    ) -> List[float]:  # pragma: no cover
         recent = self._measurements[-window:]
         if len(recent) < 2:
             return []
@@ -829,7 +849,9 @@ class BatteryHealthTracker:
         return [m.soh_percent for m in recent]
 
 
-def _percentile(values: List[float], percentile: int) -> Optional[float]:  # pragma: no cover
+def _percentile(
+    values: List[float], percentile: int
+) -> Optional[float]:  # pragma: no cover
     if not values:
         return None
     sorted_values = sorted(values)
@@ -885,7 +907,9 @@ class BatteryHealthSensor(CoordinatorEntity, SensorEntity):
         # Denní analýza
         self._daily_unsub = None  # pragma: no cover
 
-        _LOGGER.info(f"Battery Health sensor initialized for box {self._box_id}")  # pragma: no cover
+        _LOGGER.info(
+            f"Battery Health sensor initialized for box {self._box_id}"
+        )  # pragma: no cover
 
     async def async_added_to_hass(self) -> None:  # pragma: no cover
         """Při přidání do HA."""

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.1.6",
+  "version": "2.1.7",
   "zeroconf": []
 }


### PR DESCRIPTION
## Summary
- Bump integration version to 2.1.7 and update changelog.
- Fix precomputed detail tabs to use proper mode labels and make UPS detection robust.
- Include discharge sensor in statistics backfill and reduce noisy warnings.

## Testing
- `./.ha-env/bin/python -m pytest tests/ -v --tb=short -x`
- `./scripts/sonar_local.sh start`
- `./scripts/sonar_local.sh scan`

## Sonar
- Scan completed successfully at http://localhost:9001/dashboard?id=oig_cloud
- Warning: `baseline-browser-mapping` is outdated (suggests `npm i baseline-browser-mapping@latest -D`).