### PR TITLE
docs: add v2.3.2 changelog + trigger CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `battery_efficiency` sensor crash (`AttributeError: 'dict' object has no attribute 'state'`)
-  — `_history_value()` now handles HA 2026.x compressed state format (dict with `s` key)
-- Ship built `www_v2/dist/` in repository so HACS installations receive the dashboard frontend
-- Add GitHub Actions workflow to auto-rebuild `www_v2/dist` on every push to main
+  - `_history_value()` now handles HA 2026.x compressed state format (dict with `s` key)
+- Shipped built `www_v2/dist/` in repository so HACS installations receive the dashboard frontend
+- Added GitHub Actions workflow to auto-rebuild `www_v2/dist` on every push to main
 
 ## [2.2.0] - 2026-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2026-03-02
+
+### Fixed
+- `battery_efficiency` sensor crash (`AttributeError: 'dict' object has no attribute 'state'`)
+  — `_history_value()` now handles HA 2026.x compressed state format (dict with `s` key)
+- Ship built `www_v2/dist/` in repository so HACS installations receive the dashboard frontend
+- Add GitHub Actions workflow to auto-rebuild `www_v2/dist` on every push to main
+
 ## [2.2.0] - 2026-01-22
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` entry for v2.3.2
- Triggers CI to verify fixes from direct commits (`6ddc5fe`, `b9804f1`):
  - `battery_efficiency` sensor crash fix (`_history_value` dict handling)
  - `www_v2/dist` added to repo for HACS installs
  - `build-frontend.yml` workflow
  - version bump to 2.3.2