### PR TITLE
fix(auth): stabilize reauth and switch OIG API base to portal (v2.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.5] - 2026-03-11
+
+### Fixed
+- Added full reauthentication flow (`reauth` + `reauth_confirm`) so failed auth can be recovered directly from UI without deleting the integration.
+- Mapped `OigCloudAuthError` to `InvalidAuth` in config validation to prevent unexpected exception crashes during reauth.
+- Standardized OIG Cloud base URL to `https://portal.oigpower.cz/` (no fallback) and aligned API headers/endpoints with the new host.
+- Added regression tests for reauth handling, credential persistence paths, and portal-only authentication behavior.
+
 ## [2.3.4] - 2026-03-11
 
 ### Fixed

--- a/custom_components/oig_cloud/__init__.py
+++ b/custom_components/oig_cloud/__init__.py
@@ -13,7 +13,7 @@ try:
     from homeassistant.config_entries import ConfigEntry, ConfigEntryState
     from homeassistant.const import Platform
     from homeassistant.core import HomeAssistant
-    from homeassistant.exceptions import ConfigEntryNotReady
+    from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
     from homeassistant.helpers import config_validation as cv
 except ModuleNotFoundError:  # pragma: no cover
     # Allow importing submodules (e.g., planner) outside a Home Assistant runtime.
@@ -24,6 +24,7 @@ except ModuleNotFoundError:  # pragma: no cover
     Platform = Any  # type: ignore[misc,assignment]
     HomeAssistant = Any  # type: ignore[misc,assignment]
     ConfigEntryNotReady = Exception  # type: ignore[assignment]
+    ConfigEntryAuthFailed = Exception  # type: ignore[assignment]
 
     class _CvStub:  # pragma: no cover - only used outside HA
         @staticmethod
@@ -33,10 +34,11 @@ except ModuleNotFoundError:  # pragma: no cover
     cv = _CvStub()  # type: ignore[assignment]
 
 try:
-    from .lib.oig_cloud_client.api.oig_cloud_api import OigCloudApi
+    from .lib.oig_cloud_client.api.oig_cloud_api import OigCloudApi, OigCloudAuthError
 except ModuleNotFoundError:  # pragma: no cover
     # Allow importing submodules outside HA / without runtime deps.
     OigCloudApi = Any  # type: ignore[misc,assignment]
+    OigCloudAuthError = Exception  # type: ignore[misc,assignment]
 from .const import (
     CONF_AUTO_MODE_SWITCH,
     CONF_EXTENDED_SCAN_INTERVAL,
@@ -886,6 +888,29 @@ async def _start_service_shield(
     return service_shield
 
 
+def _migrate_legacy_credentials_from_options(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    updated_data = dict(entry.data)
+    changed = False
+
+    if not updated_data.get(CONF_USERNAME):
+        legacy_username = entry.options.get(CONF_USERNAME)
+        if isinstance(legacy_username, str) and legacy_username.strip():
+            updated_data[CONF_USERNAME] = legacy_username
+            changed = True
+
+    if not updated_data.get(CONF_PASSWORD):
+        legacy_password = entry.options.get(CONF_PASSWORD)
+        if isinstance(legacy_password, str) and legacy_password:
+            updated_data[CONF_PASSWORD] = legacy_password
+            changed = True
+
+    if changed:
+        hass.config_entries.async_update_entry(entry, data=updated_data)
+        _LOGGER.info("Migrated legacy credentials from options to entry.data")
+
+
 def _load_entry_auth_config(
     entry: ConfigEntry,
 ) -> tuple[str | None, str | None, bool, int, int]:
@@ -1310,6 +1335,7 @@ async def async_setup_entry(
     _init_entry_storage(hass, entry)
     init_data_source_state(hass, entry)
     _maybe_persist_box_id_from_proxy_or_local(hass, entry)
+    _migrate_legacy_credentials_from_options(hass, entry)
 
     service_shield = await _start_service_shield(hass, entry)
 
@@ -1324,7 +1350,7 @@ async def async_setup_entry(
 
         if not username or not password:
             _LOGGER.error("Username or password is missing from configuration")
-            return False
+            raise ConfigEntryAuthFailed("Missing credentials")
 
         # DEBUG: DOČASNĚ ZAKÁZAT telemetrii kvůli problémům s výkonem
         # OPRAVA: Telemetrie způsobovala nekonečnou smyčku
@@ -1439,6 +1465,11 @@ async def async_setup_entry(
         _LOGGER.debug("OIG Cloud integration setup complete")
         return True
 
+    except OigCloudAuthError as e:
+        _LOGGER.error("Authentication failed during OIG Cloud setup: %s", e)
+        raise ConfigEntryAuthFailed("Authentication failed") from e
+    except ConfigEntryAuthFailed:
+        raise
     except Exception as e:
         _LOGGER.error("Error initializing OIG Cloud: %s", e, exc_info=True)
         raise ConfigEntryNotReady(f"Error initializing OIG Cloud: {e}") from e

--- a/custom_components/oig_cloud/config/steps.py
+++ b/custom_components/oig_cloud/config/steps.py
@@ -2400,6 +2400,74 @@ class ConfigFlow(WizardMixin, config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders=self._get_step_placeholders("user"),
         )
 
+    async def async_step_reauth(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> FlowResult:
+        return await self.async_step_reauth_confirm(user_input)
+
+    async def async_step_reauth_confirm(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> FlowResult:
+        reauth_entry_id = self.context.get("entry_id")
+        existing_entry = (
+            self.hass.config_entries.async_get_entry(reauth_entry_id)
+            if reauth_entry_id
+            else None
+        )
+
+        if existing_entry is None:
+            return self.async_abort(reason="unknown")
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_USERNAME,
+                            default=existing_entry.data.get(CONF_USERNAME, ""),
+                        ): str,
+                        vol.Required(CONF_PASSWORD): str,
+                    }
+                ),
+            )
+
+        errors: Dict[str, str] = {}
+        try:
+            await validate_input(self.hass, user_input)
+        except LiveDataNotEnabled:
+            errors["base"] = "live_data_not_enabled"
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+        except Exception:
+            _LOGGER.exception("Unexpected exception during reauth")
+            errors["base"] = "unknown"
+
+        if errors:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_USERNAME,
+                            default=user_input.get(CONF_USERNAME, ""),
+                        ): str,
+                        vol.Required(CONF_PASSWORD): str,
+                    }
+                ),
+                errors=errors,
+            )
+
+        updated_data = dict(existing_entry.data)
+        updated_data[CONF_USERNAME] = user_input[CONF_USERNAME]
+        updated_data[CONF_PASSWORD] = user_input[CONF_PASSWORD]
+
+        self.hass.config_entries.async_update_entry(existing_entry, data=updated_data)
+        await self.hass.config_entries.async_reload(existing_entry.entry_id)
+        return self.async_abort(reason="reauth_successful")
+
     async def async_step_quick_setup(
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> FlowResult:

--- a/custom_components/oig_cloud/config/validation.py
+++ b/custom_components/oig_cloud/config/validation.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 import aiohttp
 
 from ..const import CONF_PASSWORD, CONF_USERNAME, DEFAULT_NAME
-from ..lib.oig_cloud_client.api.oig_cloud_api import OigCloudApi
+from ..lib.oig_cloud_client.api.oig_cloud_api import OigCloudApi, OigCloudAuthError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,8 +35,11 @@ async def validate_input(hass: Any, data: Dict[str, Any]) -> Dict[str, Any]:
     _ = hass
     api = OigCloudApi(data[CONF_USERNAME], data[CONF_PASSWORD], False)
 
-    if not await api.authenticate():
-        raise InvalidAuth
+    try:
+        if not await api.authenticate():
+            raise InvalidAuth
+    except OigCloudAuthError as err:
+        raise InvalidAuth from err
 
     try:
         stats = await api.get_stats()

--- a/custom_components/oig_cloud/lib/oig_cloud_client/api/oig_cloud_api.py
+++ b/custom_components/oig_cloud/lib/oig_cloud_client/api/oig_cloud_api.py
@@ -58,7 +58,7 @@ class OigCloudApi:
     """API client for OIG Cloud."""
 
     # API endpoints
-    _base_url: str = "https://www.oigpower.cz/cez/"
+    _base_url: str = "https://portal.oigpower.cz/"
     _login_url: str = "inc/php/scripts/Login.php"
     _get_stats_url: str = "json.php"
     _set_mode_url: str = "inc/php/scripts/Device.Set.Value.php"
@@ -222,33 +222,32 @@ LwoFE+ObVXxX674szQvIc+7WPCooVsUbwZIikzJqZb4gJQ1OQx23CgyyYlsPHIDN
                 async with aiohttp.ClientSession(
                     timeout=self._timeout, connector=connector
                 ) as session:
-                    url: str = self._base_url + self._login_url
                     data: str = json.dumps(login_command)
                     headers: Dict[str, str] = {"Content-Type": "application/json"}
 
-                    async with session.post(
-                        url, data=data, headers=headers
-                    ) as response:
+                    url: str = self._base_url + self._login_url
+                    async with session.post(url, data=data, headers=headers) as response:
                         responsecontent: str = await response.text()
-                        if response.status == 200:
-                            if responsecontent == '[[2,"",false]]':
-                                base_url = URL(self._base_url)
-                                self._phpsessid = (
-                                    session.cookie_jar.filter_cookies(base_url)
-                                    .get("PHPSESSID")
-                                    .value
+                        if response.status == 200 and responsecontent == '[[2,"",false]]':
+                            cookie_base = URL(self._base_url)
+                            cookie = session.cookie_jar.filter_cookies(cookie_base).get(
+                                "PHPSESSID"
+                            )
+                            if cookie is not None:
+                                self._phpsessid = cookie.value
+                            if mode > 0:
+                                mode_names = ["normal", "intermediate cert", "disabled"]
+                                self._logger.info(
+                                    f"✅ Authentication successful with SSL mode: {mode_names[mode]}"
                                 )
-                                if mode > 0:
-                                    mode_names = [
-                                        "normal",
-                                        "intermediate cert",
-                                        "disabled",
-                                    ]
-                                    self._logger.info(
-                                        f"✅ Authentication successful with SSL mode: {mode_names[mode]}"
-                                    )
-                                return True
-                        raise OigCloudAuthError("Authentication failed")
+                            return True
+                        self._logger.debug(
+                            "Authentication attempt failed for %s status=%s body=%s",
+                            url,
+                            response.status,
+                            responsecontent,
+                        )
+                    raise OigCloudAuthError("Authentication failed")
 
             except (asyncio.TimeoutError, ServerTimeoutError) as e:
                 self._logger.error(f"Authentication timeout: {e}")
@@ -292,8 +291,8 @@ LwoFE+ObVXxX674szQvIc+7WPCooVsUbwZIikzJqZb4gJQ1OQx23CgyyYlsPHIDN
             "Accept-Encoding": "gzip, deflate, br, zstd",
             "Accept-Language": "cs-CZ,cs;q=0.9,en;q=0.8",
             "Connection": "keep-alive",
-            "Referer": "https://www.oigpower.cz/cez/",
-            "Origin": "https://www.oigpower.cz",
+            "Referer": "https://portal.oigpower.cz/",
+            "Origin": "https://portal.oigpower.cz",
             "Sec-Ch-Ua": '"Not)A;Brand";v="99", "Google Chrome";v="141", "Chromium";v="141"',
             "Sec-Ch-Ua-Mobile": "?1",
             "Sec-Ch-Ua-Platform": '"Android"',

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.4",
+  "version": "2.3.5",
   "zeroconf": []
 }

--- a/tests/test_config_flow_entry.py
+++ b/tests/test_config_flow_entry.py
@@ -32,6 +32,68 @@ async def test_step_user_form():
 
 
 @pytest.mark.asyncio
+async def test_step_reauth_confirm_shows_form_with_existing_username():
+    entry = SimpleNamespace(data={"username": "stored_user"}, entry_id="entry-1")
+
+    class _ConfigEntries:
+        def async_get_entry(self, entry_id):
+            assert entry_id == "entry-1"
+            return entry
+
+    flow = DummyConfigFlow()
+    flow.context = {"entry_id": "entry-1"}
+    flow.hass = SimpleNamespace(config_entries=_ConfigEntries())
+
+    result = await flow.async_step_reauth_confirm()
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+
+
+@pytest.mark.asyncio
+async def test_step_reauth_confirm_updates_entry_and_reloads(monkeypatch):
+    async def _fake_validate_input(_hass, _data):
+        return {"title": "OIG Cloud"}
+
+    monkeypatch.setattr(steps_module, "validate_input", _fake_validate_input)
+
+    entry = SimpleNamespace(
+        data={"username": "old_user", "password": "old_pass"},
+        entry_id="entry-2",
+    )
+    calls: dict[str, object] = {}
+
+    class _ConfigEntries:
+        def async_get_entry(self, entry_id):
+            assert entry_id == "entry-2"
+            return entry
+
+        def async_update_entry(self, existing_entry, data=None, options=None):
+            calls["updated_entry"] = existing_entry
+            calls["updated_data"] = data
+            calls["updated_options"] = options
+
+        async def async_reload(self, entry_id):
+            calls["reloaded_entry_id"] = entry_id
+            return True
+
+    flow = DummyConfigFlow()
+    flow.context = {"entry_id": "entry-2"}
+    flow.hass = SimpleNamespace(config_entries=_ConfigEntries())
+
+    result = await flow.async_step_reauth_confirm(
+        {"username": "new_user", "password": "new_pass"}
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    assert calls["updated_entry"] is entry
+    assert calls["updated_data"] == {"username": "new_user", "password": "new_pass"}
+    assert calls["updated_options"] is None
+    assert calls["reloaded_entry_id"] == "entry-2"
+
+
+@pytest.mark.asyncio
 async def test_step_user_quick_setup():
     flow = DummyConfigFlow()
     result = await flow.async_step_user({"setup_type": "quick"})

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -7,6 +7,9 @@ import pytest
 from custom_components.oig_cloud.config import validation as validation_module
 from custom_components.oig_cloud.config.validation import InvalidAuth, LiveDataNotEnabled
 from custom_components.oig_cloud.const import CONF_PASSWORD, CONF_USERNAME
+from custom_components.oig_cloud.lib.oig_cloud_client.api.oig_cloud_api import (
+    OigCloudAuthError,
+)
 
 
 class DummyApi:
@@ -30,6 +33,28 @@ async def test_validate_input_invalid_auth(monkeypatch):
     with pytest.raises(InvalidAuth):
         await validation_module.validate_input(
             SimpleNamespace(), {CONF_USERNAME: "u", CONF_PASSWORD: "p"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_validate_input_maps_oig_auth_error_to_invalid_auth(monkeypatch):
+    class FailingAuthApi:
+        async def authenticate(self):
+            raise OigCloudAuthError("Authentication failed")
+
+        async def get_stats(self):
+            return {"box": {"actual": {}}}
+
+    monkeypatch.setattr(
+        validation_module,
+        "OigCloudApi",
+        lambda *_a, **_k: FailingAuthApi(),
+    )
+
+    with pytest.raises(InvalidAuth):
+        await validation_module.validate_input(
+            SimpleNamespace(),
+            {CONF_USERNAME: "u", CONF_PASSWORD: "p"},
         )
 
 

--- a/tests/test_init_setup_entry.py
+++ b/tests/test_init_setup_entry.py
@@ -8,7 +8,7 @@ import pytest
 import custom_components.oig_cloud as init_module
 from custom_components.oig_cloud.const import CONF_PASSWORD, CONF_USERNAME, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 
 class DummyConfigEntries:
@@ -17,8 +17,11 @@ class DummyConfigEntries:
         self.forwarded = []
         self.unloaded = []
 
-    def async_update_entry(self, entry, options=None):
-        entry.options = options or {}
+    def async_update_entry(self, entry, options=None, data=None):
+        if options is not None:
+            entry.options = options
+        if data is not None:
+            entry.data = data
         self.updated.append(entry)
 
     async def async_forward_entry_setups(self, entry, platforms):
@@ -195,9 +198,81 @@ async def test_async_setup_entry_missing_credentials(monkeypatch):
     entry = DummyEntry(data={}, options={})
     hass.data[DOMAIN] = {entry.entry_id: {}}
 
-    result = await init_module.async_setup_entry(hass, entry)
+    with pytest.raises(ConfigEntryAuthFailed):
+        await init_module.async_setup_entry(hass, entry)
 
-    assert result is False
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_migrates_legacy_credentials_from_options(monkeypatch):
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.shield.core.ServiceShield", DummyShield
+    )
+    monkeypatch.setattr(init_module, "OigCloudApi", DummyApi)
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.api.oig_cloud_session_manager.OigCloudSessionManager",
+        DummySessionManager,
+    )
+    monkeypatch.setattr(init_module, "OigCloudCoordinator", DummyCoordinator)
+    monkeypatch.setattr(init_module, "DataSourceController", DummyDataSourceController)
+    monkeypatch.setattr(init_module, "init_data_source_state", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        init_module,
+        "get_data_source_state",
+        lambda *_a, **_k: SimpleNamespace(
+            effective_mode="local_only",
+            configured_mode="local_only",
+            local_available=True,
+        ),
+    )
+
+    async def _noop(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(init_module, "_cleanup_invalid_empty_devices", _noop)
+    monkeypatch.setattr(init_module, "_remove_frontend_panel", _noop)
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.services.async_setup_services", _noop
+    )
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.services.async_setup_entry_services_with_shield",
+        _noop,
+    )
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.api.planning_api.setup_planning_api_views",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.api.ha_rest_api.setup_api_endpoints",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        "homeassistant.helpers.event.async_track_time_interval",
+        lambda *_a, **_k: lambda: None,
+    )
+
+    hass = DummyHass()
+    entry = DummyEntry(
+        data={},
+        options={
+            CONF_USERNAME: "legacy_user",
+            CONF_PASSWORD: "legacy_pass",
+            "enable_cloud_notifications": False,
+            "enable_solar_forecast": False,
+            "enable_statistics": True,
+            "enable_pricing": False,
+            "enable_boiler": False,
+            "enable_battery_prediction": False,
+            "enable_dashboard": False,
+            "enable_chmu_warnings": False,
+            "enable_extended_sensors": False,
+            "balancing_enabled": False,
+        },
+    )
+
+    ok = await init_module.async_setup_entry(hass, entry)
+    assert ok is True
+    assert entry.data[CONF_USERNAME] == "legacy_user"
+    assert entry.data[CONF_PASSWORD] == "legacy_pass"
 
 
 @pytest.mark.asyncio

--- a/tests/test_oig_cloud_api.py
+++ b/tests/test_oig_cloud_api.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import importlib
+import importlib.util
 import ssl
 import json
 import sys
@@ -548,7 +549,7 @@ class TestOigCloudApi:
             result = await self.api.set_box_params_internal("table", "column", "value")
         assert result is True
 
-        expected_url = f"https://www.oigpower.cz/cez/inc/php/scripts/Device.Set.Value.php?_nonce={nonce}"
+        expected_url = f"https://portal.oigpower.cz/inc/php/scripts/Device.Set.Value.php?_nonce={nonce}"
         expected_data = json.dumps(
             {
                 "id_device": "test_box_id",
@@ -602,7 +603,7 @@ class TestOigCloudApi:
             result = await self.api.set_grid_delivery(1)
         assert result is True
 
-        expected_url = f"https://www.oigpower.cz/cez/inc/php/scripts/ToGrid.Toggle.php?_nonce={nonce}"
+        expected_url = f"https://portal.oigpower.cz/inc/php/scripts/ToGrid.Toggle.php?_nonce={nonce}"
         expected_data = json.dumps(
             {
                 "id_device": "test_box_id",
@@ -661,7 +662,7 @@ class TestOigCloudApi:
             result = await self.api.set_battery_formating("1", 80)
         assert result is True
 
-        expected_url = f"https://www.oigpower.cz/cez/inc/php/scripts/Battery.Format.Save.php?_nonce={nonce}"
+        expected_url = f"https://portal.oigpower.cz/inc/php/scripts/Battery.Format.Save.php?_nonce={nonce}"
         session.post.assert_called_once()
         assert expected_url in session.post.call_args[0][0]
 
@@ -693,7 +694,7 @@ class TestOigCloudApi:
             result = await self.api.set_formating_mode("1")
         assert result is True
 
-        expected_url = f"https://www.oigpower.cz/cez/inc/php/scripts/Battery.Format.Save.php?_nonce={nonce}"
+        expected_url = f"https://portal.oigpower.cz/inc/php/scripts/Battery.Format.Save.php?_nonce={nonce}"
         expected_data = json.dumps(
             {
                 "bat_ac": "1",


### PR DESCRIPTION
## Summary
- add robust Home Assistant reauth flow (`reauth` + `reauth_confirm`) with credential update + entry reload
- map `OigCloudAuthError` to `InvalidAuth` in config validation to avoid unexpected exception crashes in reauth
- switch OIG API client to portal-only base URL (`https://portal.oigpower.cz/`) and release as `2.3.5`

## Verification
- `./venv/bin/python -m pytest tests/test_config_validation.py tests/test_config_flow_entry.py tests/test_init_setup_entry.py tests/test_oig_cloud_api.py -k "reauth or authenticate or missing_credentials or portal"`
- `./venv/bin/python -m pytest tests/test_oig_cloud_api.py -k "authenticate_success or authenticate_failure_wrong_response or authenticate_failure_http_error"`
- `./venv/bin/python -m pytest tests/test_config_validation.py tests/test_config_flow_entry.py`

## Notes
- split into two commits: functional auth/reauth fixes + version/changelog bump for release