### PR TITLE
v2.3.8 - Fix None values in extended_fve_current sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.8] - 2026-03-17
+
+### Fixed
+- `extended_fve_current_1` and `extended_fve_current_2` sensors now handle None values gracefully instead of raising TypeError
+
 ## [2.3.7] - 2026-03-16
 
 ### Changed

--- a/custom_components/oig_cloud/entities/data_sensor.py
+++ b/custom_components/oig_cloud/entities/data_sensor.py
@@ -426,13 +426,19 @@ class OigCloudDataSensor(CoordinatorEntity, SensorEntity, RestoreEntity):
             last_values = extended_fve["items"][-1]["values"]
 
             if sensor_type == "extended_fve_current_1":
-                # Index 3 = power_1, Index 0 = voltage_1
-                power = float(last_values[3])  # extended_fve_power_1
-                voltage = float(last_values[0])  # extended_fve_voltage_1
+                power_raw = last_values[3]
+                voltage_raw = last_values[0]
+                if power_raw is None or voltage_raw is None:
+                    return None
+                power = float(power_raw)
+                voltage = float(voltage_raw)
             elif sensor_type == "extended_fve_current_2":
-                # Index 4 = power_2, Index 1 = voltage_2
-                power = float(last_values[4])  # extended_fve_power_2
-                voltage = float(last_values[1])  # extended_fve_voltage_2
+                power_raw = last_values[4]
+                voltage_raw = last_values[1]
+                if power_raw is None or voltage_raw is None:
+                    return None
+                power = float(power_raw)
+                voltage = float(voltage_raw)
             else:
                 return None
 

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.7",
+  "version": "2.3.8",
   "zeroconf": []
 }


### PR DESCRIPTION
## Fix

- `extended_fve_current_1` and `extended_fve_current_2` sensors now handle None values gracefully instead of raising TypeError

## Tests
- All 3129 tests pass