### PR TITLE
v2.3.9 - Fix sensor warnings and state class issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.9] - 2026-03-17
+
+### Fixed
+- `extended_grid_consumption` sensor changed from `total_increasing` to `total` state class to prevent warnings when API reports corrected/reset values
+- Battery health sensor SoH rejection messages changed from WARNING to DEBUG level (these are expected measurement errors, not system issues)
+
 ## [2.3.8] - 2026-03-17
 
 ### Fixed

--- a/custom_components/oig_cloud/entities/battery_health_sensor.py
+++ b/custom_components/oig_cloud/entities/battery_health_sensor.py
@@ -706,7 +706,7 @@ class BatteryHealthTracker:
         soh_percent = (capacity_kwh / self._nominal_capacity_kwh) * 100.0
 
         if soh_percent > 105.0:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Interval rejected: SoH %.1f%% > 105%% (measurement error), "
                 "capacity=%.2f kWh, ΔSoC=%.0f%%, charge=%.0f Wh, eff=%.1f%%%s",
                 soh_percent,
@@ -718,7 +718,7 @@ class BatteryHealthTracker:
             )
             return None
         if soh_percent < 70.0:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Interval rejected: SoH %.1f%% < 70%% (extreme degradation or error), "
                 "capacity=%.2f kWh, ΔSoC=%.0f%%, charge=%.0f Wh, eff=%.1f%%%s",
                 soh_percent,

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.8",
+  "version": "2.3.9",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/sensors/SENSOR_TYPES_EXTENDED_GRID.py
+++ b/custom_components/oig_cloud/sensors/SENSOR_TYPES_EXTENDED_GRID.py
@@ -28,10 +28,10 @@ SENSOR_TYPES_EXTENDED_GRID: Dict[str, Dict[str, Any]] = {
     },
     "extended_grid_consumption": {
         "name": "Extended Grid Consumption",
-        "name_cs": "Rozšířená spotřeba ze sítě",
+        "name_cs": "Rozšířená spotřeba z sítě",
         "unit_of_measurement": UnitOfEnergy.WATT_HOUR,
         "device_class": SensorDeviceClass.ENERGY,
-        "state_class": SensorStateClass.TOTAL_INCREASING,
+        "state_class": SensorStateClass.TOTAL,
         "node_id": None,
         "node_key": None,
         "sensor_type_category": "extended",


### PR DESCRIPTION
## Fixes

### extended_grid_consumption state class
- Changed from `total_increasing` to `total` to prevent HA warnings when API reports corrected/reset values
- The API can report decreasing values due to meter resets or corrections

### Battery health sensor logging
- Changed SoH rejection messages from WARNING to DEBUG level
- SoH > 105% or < 70% are expected measurement errors, not system issues
- These rejections are normal behavior when filtering invalid data

## Tests
- All 3129 tests pass