### PR TITLE
v2.3.10 - Read battery capacity from sensor instead of hardcoded value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.10] - 2026-03-17
+
+### Fixed
+- Battery health sensor now reads actual battery capacity from `installed_battery_capacity_kwh` sensor instead of hardcoded 15.3 kWh value
+- SoH calculations now correctly reflect the real battery capacity when it differs from the default
+
 ## [2.3.9] - 2026-03-17
 
 ### Fixed

--- a/custom_components/oig_cloud/entities/battery_health_sensor.py
+++ b/custom_components/oig_cloud/entities/battery_health_sensor.py
@@ -79,6 +79,23 @@ class BatteryHealthTracker:
             f"BatteryHealthTracker initialized, nominal capacity: {nominal_capacity_kwh:.2f} kWh"
         )
 
+    def _get_nominal_capacity_kwh(self) -> float:
+        """Get nominal battery capacity from sensor, fallback to stored value."""
+        if not self._hass:
+            return self._nominal_capacity_kwh
+
+        installed_sensor = f"sensor.oig_{self._box_id}_installed_battery_capacity_kwh"
+        state = self._hass.states.get(installed_sensor)
+        if state and state.state not in (None, "unknown", "unavailable"):
+            try:
+                capacity_kwh = float(state.state)
+                if capacity_kwh > 0:
+                    return capacity_kwh
+            except (ValueError, TypeError):
+                pass
+
+        return self._nominal_capacity_kwh
+
     async def async_load_from_storage(self) -> None:  # pragma: no cover
         """Načíst uložená měření ze storage."""
         try:
@@ -703,7 +720,8 @@ class BatteryHealthTracker:
             return None
 
         capacity_kwh = (stored_energy / 1000.0) / (delta_soc / 100.0)
-        soh_percent = (capacity_kwh / self._nominal_capacity_kwh) * 100.0
+        nominal_capacity = self._get_nominal_capacity_kwh()
+        soh_percent = (capacity_kwh / nominal_capacity) * 100.0
 
         if soh_percent > 105.0:
             _LOGGER.debug(
@@ -898,8 +916,8 @@ class BatteryHealthSensor(CoordinatorEntity, SensorEntity):
         self.entity_id = f"sensor.oig_{self._box_id}_{sensor_type}"  # pragma: no cover
         self._attr_name = "Battery Health (SoH)"
 
-        # Nominální kapacita
-        self._nominal_capacity_kwh: float = 15.3  # kWh - skutečná kapacita baterie
+        # Nominální kapacita - fallback, bude aktualizována ze sensoru
+        self._nominal_capacity_kwh: float = 15.3  # kWh - fallback hodnota
 
         # Tracker - bude inicializován v async_added_to_hass
         self._tracker: Optional[BatteryHealthTracker] = None
@@ -911,9 +929,34 @@ class BatteryHealthSensor(CoordinatorEntity, SensorEntity):
             f"Battery Health sensor initialized for box {self._box_id}"
         )  # pragma: no cover
 
+    def _get_nominal_capacity_kwh(self) -> float:
+        """Get nominal battery capacity from sensor, fallback to default."""
+        if not self._hass_ref:
+            return self._nominal_capacity_kwh
+
+        installed_sensor = f"sensor.oig_{self._box_id}_installed_battery_capacity_kwh"
+        state = self._hass_ref.states.get(installed_sensor)
+        if state and state.state not in (None, "unknown", "unavailable"):
+            try:
+                capacity_kwh = float(state.state)
+                if capacity_kwh > 0:
+                    return capacity_kwh
+            except (ValueError, TypeError):
+                pass
+
+        return self._nominal_capacity_kwh
+
     async def async_added_to_hass(self) -> None:  # pragma: no cover
         """Při přidání do HA."""
         await super().async_added_to_hass()
+
+        # Aktualizovat nominální kapacitu ze sensoru
+        actual_capacity = self._get_nominal_capacity_kwh()
+        if actual_capacity != self._nominal_capacity_kwh:
+            _LOGGER.info(
+                f"Battery nominal capacity updated from sensor: {actual_capacity} kWh (was {self._nominal_capacity_kwh} kWh)"
+            )
+            self._nominal_capacity_kwh = actual_capacity
 
         # Inicializovat tracker
         self._tracker = BatteryHealthTracker(

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.9",
+  "version": "2.3.10",
   "zeroconf": []
 }


### PR DESCRIPTION
## Fix

Battery health sensor nyní čte skutečnou kapacitu baterie ze sensoru `installed_battery_capacity_kwh` místo hardcoded hodnoty 15.3 kWh.

### Problém
- Když se kapacita baterie změní (např. 10.24 kWh místo 15.3 kWh), SoH výpočet dával nesmyslné hodnoty (175%+)
- Sensor odmítal platná měření jako "measurement error"

### Řešení
- `BatteryHealthTracker._get_nominal_capacity_kwh()` čte kapacitu ze sensoru
- Fallback na hardcoded hodnotu pokud sensor není dostupný

## Tests
- All 3129 tests pass