### PR TITLE
fix: unblock startup and restore legacy entity names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.11] - 2026-04-01
+
+### Fixed
+- Battery forecast setup no longer waits for adaptive load profiles during startup, and related precompute/statistics restore work now runs in the background so Home Assistant setup is not blocked.
+- Existing OIG sensor and switch entities now migrate to explicit short registry names during setup, preventing newer Home Assistant versions from prepending device names to legacy entity labels.
+
 ## [2.3.10] - 2026-03-17
 
 ### Fixed

--- a/custom_components/oig_cloud/__init__.py
+++ b/custom_components/oig_cloud/__init__.py
@@ -724,6 +724,46 @@ def _device_has_entities(entity_registry: Any, device_id: str) -> bool:
     return bool(er.async_entries_for_device(entity_registry, device_id))
 
 
+def _is_legacy_name_migration_candidate(entity: Any) -> bool:
+    entity_id = getattr(entity, "entity_id", "")
+    if not entity_id.startswith(("sensor.oig_", "switch.oig_")):
+        return False
+
+    name = getattr(entity, "name", None)
+    original_name = getattr(entity, "original_name", None)
+    return name is None and isinstance(original_name, str) and bool(original_name.strip())
+
+
+async def _migrate_entity_names_to_legacy_short_names(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    try:
+        from homeassistant.helpers import entity_registry as er
+
+        entity_registry = er.async_get(hass)
+        entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        migrated = 0
+
+        for entity in entities:
+            if not _is_legacy_name_migration_candidate(entity):
+                continue
+
+            entity_registry.async_update_entity(
+                entity.entity_id,
+                name=entity.original_name,
+                has_entity_name=False,
+            )
+            migrated += 1
+
+        if migrated:
+            _LOGGER.info(
+                "Applied legacy short-name migration to %s OIG entities",
+                migrated,
+            )
+    except Exception as err:
+        _LOGGER.debug("Entity name migration skipped (non-critical): %s", err)
+
+
 def _is_valid_device_base(bases: set[str], allowlisted_bases: set[str]) -> bool:
     if not bases:
         return True
@@ -1461,6 +1501,7 @@ async def async_setup_entry(
         # Targeted cleanup for stale/invalid devices (e.g., 'spot_prices', 'unknown')
         # that can be left behind after unique_id/device_id stabilization.
         await _cleanup_invalid_empty_devices(hass, entry)
+        await _migrate_entity_names_to_legacy_short_names(hass, entry)
 
         await _sync_dashboard_panel(hass, entry, dashboard_enabled)
 

--- a/custom_components/oig_cloud/battery_forecast/presentation/precompute.py
+++ b/custom_components/oig_cloud/battery_forecast/presentation/precompute.py
@@ -73,8 +73,10 @@ def schedule_precompute(sensor: Any, *, force: bool = False) -> None:
     async def _runner():
         await _run_precompute_task(sensor)
 
-    sensor._precompute_task = sensor.hass.async_create_task(
-        _runner()
+    sensor._precompute_task = _create_background_task(
+        sensor,
+        _runner(),
+        "oig_cloud_battery_forecast_precompute",
     )  # pylint: disable=protected-access
 
 
@@ -144,3 +146,16 @@ async def _run_precompute_task(sensor: Any) -> None:
         _LOGGER.error("[Precompute] Job failed: %s", err, exc_info=True)
     finally:
         sensor._precompute_task = None  # pylint: disable=protected-access
+
+
+def _create_background_task(sensor: Any, coro: Any, name: str) -> Any:
+    hass = getattr(sensor, "hass", None)
+    if not hass:
+        if hasattr(coro, "close"):
+            coro.close()
+        return None
+
+    create_background = getattr(hass, "async_create_background_task", None)
+    if callable(create_background):
+        return create_background(coro, name=name)
+    return hass.async_create_task(coro)

--- a/custom_components/oig_cloud/battery_forecast/sensors/sensor_lifecycle.py
+++ b/custom_components/oig_cloud/battery_forecast/sensors/sensor_lifecycle.py
@@ -6,7 +6,7 @@ import asyncio
 import copy
 import json
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import async_track_time_change
@@ -99,7 +99,7 @@ def _parse_last_update(last_update: str | None):
     if isinstance(last_update, str) and last_update:
         try:
             parsed = dt_util.parse_datetime(last_update)
-            return parsed or dt_util.dt.datetime.fromisoformat(last_update)
+            return parsed or datetime.fromisoformat(last_update)
         except Exception:
             return dt_util.now()
     return dt_util.now()  # pragma: no cover
@@ -194,10 +194,15 @@ def _subscribe_profiles(sensor) -> None:
         await asyncio.sleep(0)
         sensor._profiles_dirty = True
         sensor._log_rate_limited(
-            "profiles_updated_deferred",
+            "profiles_updated_refresh",
             "info",
-            " profiles_updated received - deferring forecast refresh to next 15-min tick",
+            " profiles_updated received - scheduling immediate forecast refresh",
             cooldown_s=300.0,
+        )
+        _create_background_task(
+            sensor,
+            _refresh_forecast(sensor, "Profiles-driven forecast refresh failed"),
+            "oig_cloud_battery_forecast_profiles_refresh",
         )
 
     signal_name = f"oig_cloud_{sensor._box_id}_profiles_updated"
@@ -206,36 +211,47 @@ def _subscribe_profiles(sensor) -> None:
 
 
 def _schedule_initial_refresh(sensor) -> None:
-    async def _delayed_initial_refresh():
-        _LOGGER.info(" Waiting for AdaptiveLoadProfiles to complete (max 60s)...")
-        profiles_ready = False
+    _create_background_task(
+        sensor,
+        _refresh_forecast(
+            sensor,
+            "Initial forecast failed",
+            start_message=" Starting initial forecast asynchronously without waiting for AdaptiveLoadProfiles",
+            success_message=" Initial forecast completed",
+        ),
+        "oig_cloud_battery_forecast_initial_refresh",
+    )
 
-        async def _mark_ready():
-            nonlocal profiles_ready
-            await asyncio.sleep(0)
-            profiles_ready = True
 
-        temp_unsub = async_dispatcher_connect(
-            sensor.hass, f"oig_cloud_{sensor._box_id}_profiles_updated", _mark_ready
-        )
+async def _refresh_forecast(
+    sensor,
+    error_message: str,
+    *,
+    start_message: str | None = None,
+    success_message: str | None = None,
+):
+    try:
+        if start_message:
+            _LOGGER.info(start_message)
+        await asyncio.sleep(0)
+        await sensor.async_update()
+        if success_message:
+            _LOGGER.info(success_message)
+    except Exception as err:
+        _LOGGER.error("%s: %s", error_message, err, exc_info=True)
 
-        try:
-            for _ in range(60):
-                if profiles_ready:
-                    _LOGGER.info(" Profiles ready - starting initial forecast")
-                    break
-                await asyncio.sleep(1)
-            else:
-                _LOGGER.info("Profiles not ready after 60s - starting forecast anyway")
 
-            await sensor.async_update()
-            _LOGGER.info(" Initial forecast completed")
-        except Exception as err:
-            _LOGGER.error("Initial forecast failed: %s", err, exc_info=True)
-        finally:
-            temp_unsub()
+def _create_background_task(sensor, coro, name: str):
+    hass = getattr(sensor, "hass", None)
+    if not hass:
+        if hasattr(coro, "close"):
+            coro.close()
+        return None
 
-    sensor.hass.async_create_task(_delayed_initial_refresh())
+    create_background = getattr(hass, "async_create_background_task", None)
+    if callable(create_background):
+        return create_background(coro, name=name)
+    return hass.async_create_task(coro)
 
 
 def _schedule_aggregations(sensor) -> None:

--- a/custom_components/oig_cloud/entities/statistics_sensor.py
+++ b/custom_components/oig_cloud/entities/statistics_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from statistics import median
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -127,8 +127,12 @@ class OigCloudStatisticsSensor(SensorEntity, RestoreEntity):
         # Načtení konfigurace senzoru
         if hasattr(self, "_sensor_config"):
             config = self._sensor_config
-            self._sampling_minutes = config.get("sampling_minutes", 10)
-            self._max_sampling_size = config.get("sampling_size", 1000)
+            sampling_minutes = config.get("sampling_minutes", 10)
+            if isinstance(sampling_minutes, int):
+                self._sampling_minutes = sampling_minutes
+            sampling_size = config.get("sampling_size", 1000)
+            if isinstance(sampling_size, int):
+                self._max_sampling_size = sampling_size
             self._time_range = config.get("time_range")
             self._day_type = config.get("day_type")
             self._statistic = config.get("statistic", "median")
@@ -146,9 +150,6 @@ class OigCloudStatisticsSensor(SensorEntity, RestoreEntity):
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
-
-        # Načtení persistentních dat
-        await self._load_statistics_data()
 
         # Inicializace StatisticsStore pro batched writes (low-power optimalization)
         try:
@@ -185,6 +186,25 @@ class OigCloudStatisticsSensor(SensorEntity, RestoreEntity):
             )
             # První výpočet po startu (neblokuj setup – může to trvat dlouho kvůli recorder historii)
             self.hass.async_create_task(self._daily_statistics_update(None))
+
+        self._schedule_startup_load()
+
+    def _schedule_startup_load(self) -> None:
+        if not self.hass:
+            return
+
+        async def _startup_load() -> None:
+            await self._load_statistics_data()
+
+        create_background = getattr(self.hass, "async_create_background_task", None)
+        if callable(create_background):
+            create_background(
+                _startup_load(),
+                name=f"oig_cloud_statistics_startup_load_{self._sensor_type}",
+            )
+            return
+
+        self.hass.async_create_task(_startup_load())
 
     async def _load_statistics_data(self) -> None:
         """Načte statistická data z persistentního úložiště."""
@@ -224,6 +244,13 @@ class OigCloudStatisticsSensor(SensorEntity, RestoreEntity):
                         f"[{self.entity_id}] Restored hourly state: {self._current_hourly_value} kWh"
                     )
                     self.async_write_ha_state()
+                elif self._interval_data and hasattr(self, "_time_range"):
+                    restored_state = self._calculate_statistics_value()
+                    if restored_state is not None:
+                        _LOGGER.debug(
+                            f"[{self.entity_id}] Restored interval state: {restored_state}"
+                        )
+                        self.async_write_ha_state()
 
         except Exception as e:
             _LOGGER.warning(f"[{self.entity_id}] Failed to load statistics data: {e}")
@@ -580,7 +607,7 @@ class OigCloudStatisticsSensor(SensorEntity, RestoreEntity):
                 )
         return daily_medians
 
-    def _should_include_day(self, day_date: datetime.date) -> bool:
+    def _should_include_day(self, day_date: date) -> bool:
         day_datetime = datetime.combine(day_date, datetime.min.time())
         is_weekend = day_datetime.weekday() >= 5
 
@@ -594,7 +621,7 @@ class OigCloudStatisticsSensor(SensorEntity, RestoreEntity):
     def _extract_day_values(
         self,
         state_list: List[Any],
-        day_date: datetime.date,
+        day_date: date,
         start_hour: int,
         end_hour: int,
     ) -> List[float]:

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.10",
+  "version": "2.3.11",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/sensor.py
+++ b/custom_components/oig_cloud/sensor.py
@@ -1420,6 +1420,7 @@ def _register_all_sensors(
     async_add_entities: AddEntitiesCallback, all_sensors: List[Any]
 ) -> None:
     if all_sensors:
+        _apply_legacy_entity_naming(all_sensors)
         _LOGGER.info(
             f"🚀 Registering {len(all_sensors)} sensors in one batch (PERFORMANCE OPTIMIZATION)"
         )
@@ -1427,6 +1428,17 @@ def _register_all_sensors(
         _LOGGER.info(f"✅ All {len(all_sensors)} sensors registered successfully")
     else:
         _LOGGER.warning("⚠️ No sensors were created during setup")
+
+
+def _apply_legacy_entity_naming(entities: List[Any]) -> None:
+    for entity in entities:
+        try:
+            setattr(entity, "_attr_has_entity_name", False)
+        except Exception:
+            _LOGGER.debug(
+                "Could not enforce legacy naming for entity %s",
+                getattr(entity, "entity_id", "unknown"),
+            )
 
 
 async def async_setup_entry(  # noqa: C901

--- a/custom_components/oig_cloud/switch.py
+++ b/custom_components/oig_cloud/switch.py
@@ -93,7 +93,7 @@ async def async_setup_entry(
 class BoilerWrapperSwitch(SwitchEntity):
     """Wrapper switch delegating to a configured target entity."""
 
-    _attr_has_entity_name = True
+    _attr_has_entity_name = False
 
     def __init__(
         self,

--- a/tests/test_boiler_switch_wrapper.py
+++ b/tests/test_boiler_switch_wrapper.py
@@ -74,6 +74,7 @@ async def test_boiler_switch_wrapper_turns_on_and_off():
 
     assert wrapper.entity_id == "switch.oig_123_bojler_top"
     assert wrapper.unique_id == "oig_cloud_123_boiler_bojler_top"
+    assert wrapper._attr_has_entity_name is False
 
     await wrapper.async_turn_on()
     await wrapper.async_turn_off()

--- a/tests/test_entities_statistics_sensor.py
+++ b/tests/test_entities_statistics_sensor.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from typing import Any, ClassVar
 
 import pytest
 
@@ -54,14 +56,15 @@ def test_statistics_processor_process_hourly_data():
 class DummyCoordinator:
     def __init__(self):
         self.data = {"123": {}}
+        self.config_entry: Any = None
 
     def async_add_listener(self, *_args, **_kwargs):
         return lambda: None
 
 
 class DummyStore:
-    data = None
-    saved = None
+    data: ClassVar[Any] = None
+    saved: ClassVar[Any] = None
 
     def __init__(self, hass, version, key):
         self.hass = hass
@@ -73,6 +76,25 @@ class DummyStore:
 
     async def async_save(self, data):
         DummyStore.saved = data
+
+
+class DummyHass:
+    def __init__(self, state_map=None):
+        self.states = DummyStates(state_map or {})
+        self.background_created = []
+        self.created = []
+        try:
+            self.loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.loop = asyncio.new_event_loop()
+
+    def async_create_task(self, coro):
+        self.created.append(coro)
+        return coro
+
+    def async_create_background_task(self, coro, name=None):
+        self.background_created.append((coro, name))
+        return coro
 
 
 class DummyStates:
@@ -100,7 +122,7 @@ def _make_sensor(sensor_type="battery_load_median", state_map=None, options=None
     coordinator.config_entry = SimpleNamespace(options=options)
     device_info = {"identifiers": {("oig_cloud", "123")}}
     sensor = OigCloudStatisticsSensor(coordinator, sensor_type, device_info)
-    sensor.hass = SimpleNamespace(states=DummyStates(state_map or {}))
+    sensor.hass = DummyHass(state_map or {})
     sensor.async_write_ha_state = lambda: None
     return sensor
 
@@ -136,6 +158,29 @@ async def test_load_statistics_data(monkeypatch):
     assert sensor._interval_data[today_key] == [1.0, 2.0]
     assert len(sensor._hourly_data) == 1
     assert sensor._current_hourly_value == 0.7
+
+
+@pytest.mark.asyncio
+async def test_async_added_to_hass_backgrounds_startup_load(monkeypatch):
+    sensor = _make_sensor()
+    calls = {"load": 0}
+
+    async def fake_load():
+        calls["load"] += 1
+
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.entities.statistics_sensor.StatisticsStore.get_instance",
+        lambda _hass: SimpleNamespace(),
+    )
+    monkeypatch.setattr(sensor, "_load_statistics_data", fake_load)
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.hass.background_created
+    coro, name = sensor.hass.background_created[0]
+    assert name == "oig_cloud_statistics_startup_load_battery_load_median"
+    await coro
+    assert calls["load"] == 1
 
 
 @pytest.mark.asyncio
@@ -390,12 +435,12 @@ async def test_calculate_interval_statistics_from_history_cross_midnight(monkeyp
         min = datetime.min
 
         @classmethod
-        def now(cls):
+        def now(cls, tz=None):
             return fixed_now
 
         @classmethod
-        def combine(cls, date, time_obj):
-            return datetime.combine(date, time_obj)
+        def combine(cls, date, time, tzinfo=None):
+            return datetime.combine(date, time, tzinfo)
 
     monkeypatch.setattr(
         "custom_components.oig_cloud.entities.statistics_sensor.datetime", FixedDatetime

--- a/tests/test_init_setup_entry.py
+++ b/tests/test_init_setup_entry.py
@@ -170,11 +170,86 @@ class DummyModeTracker:
         return None
 
 
+class DummyEntityRegistry:
+    def __init__(self):
+        self.updated = []
+
+    def async_update_entity(self, entity_id, **changes):
+        self.updated.append((entity_id, changes))
+
+
 class RaisingOptions(dict):
     def get(self, key, default=None):
         if key == "box_id":
             raise RuntimeError("boom")
         return super().get(key, default)
+
+
+@pytest.mark.asyncio
+async def test_migrate_entity_names_to_legacy_short_names(monkeypatch):
+    registry = DummyEntityRegistry()
+    entities = [
+        SimpleNamespace(
+            entity_id="sensor.oig_123_actual_aco_p",
+            name=None,
+            original_name="Zátěž celkem (live)",
+        ),
+        SimpleNamespace(
+            entity_id="switch.oig_123_bojler_top",
+            name="Custom boiler",
+            original_name="Bojler top",
+        ),
+        SimpleNamespace(
+            entity_id="sensor.other_domain_sensor",
+            name=None,
+            original_name="Ignored",
+        ),
+    ]
+
+    monkeypatch.setattr(
+        "homeassistant.helpers.entity_registry.async_get",
+        lambda _hass: registry,
+    )
+    monkeypatch.setattr(
+        "homeassistant.helpers.entity_registry.async_entries_for_config_entry",
+        lambda _registry, _entry_id: entities,
+    )
+
+    await init_module._migrate_entity_names_to_legacy_short_names(
+        DummyHass(),
+        DummyEntry(),
+    )
+
+    assert registry.updated == [
+        (
+            "sensor.oig_123_actual_aco_p",
+            {"name": "Zátěž celkem (live)", "has_entity_name": False},
+        )
+    ]
+
+
+def test_is_legacy_name_migration_candidate():
+    assert init_module._is_legacy_name_migration_candidate(
+        SimpleNamespace(
+            entity_id="sensor.oig_123_data_source",
+            name=None,
+            original_name="Data source",
+        )
+    )
+    assert not init_module._is_legacy_name_migration_candidate(
+        SimpleNamespace(
+            entity_id="sensor.oig_123_data_source",
+            name="Custom name",
+            original_name="Data source",
+        )
+    )
+    assert not init_module._is_legacy_name_migration_candidate(
+        SimpleNamespace(
+            entity_id="sensor.other_domain",
+            name=None,
+            original_name="Ignored",
+        )
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_precompute.py
+++ b/tests/test_precompute.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -20,11 +21,11 @@ class DummyStore:
 
 class DummySensor:
     def __init__(self):
-        self._precomputed_store = DummyStore()
+        self._precomputed_store: Any = DummyStore()
         self._timeline_data = [{"time": "t"}]
         self._data_hash = "hash"
         self._last_precompute_hash = None
-        self._last_precompute_at = None
+        self._last_precompute_at: Any = None
         self._precompute_interval = timedelta(seconds=60)
         self._precompute_task = None
         self._box_id = "123"
@@ -106,3 +107,31 @@ def test_schedule_precompute_creates_task(monkeypatch):
 
     assert created["coro"] is not None
     assert sensor._precompute_task is not None
+
+
+def test_schedule_precompute_prefers_background_task(monkeypatch):
+    sensor = DummySensor()
+    created = {"background": None}
+
+    def _create_background_task(coro, name=None):
+        created["background"] = (coro, name)
+        if hasattr(coro, "close"):
+            coro.close()
+        return SimpleNamespace(done=lambda: False)
+
+    sensor.hass = SimpleNamespace(
+        async_create_background_task=_create_background_task,
+        async_create_task=lambda coro: (_ for _ in ()).throw(
+            AssertionError("fallback should not be used")
+        ),
+    )
+
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.battery_forecast.presentation.precompute.precompute_ui_data",
+        lambda *_a, **_k: None,
+    )
+
+    precompute_module.schedule_precompute(sensor, force=True)
+
+    assert created["background"] is not None
+    assert created["background"][1] == "oig_cloud_battery_forecast_precompute"

--- a/tests/test_sensor_lifecycle.py
+++ b/tests/test_sensor_lifecycle.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -39,8 +40,8 @@ class DummyHass:
 
 class DummySensor:
     def __init__(self):
-        self._plans_store = None
-        self._precomputed_store = None
+        self._plans_store: Any = None
+        self._precomputed_store: Any = None
         self._hass = DummyHass()
         self.hass = self._hass
         self._config_entry = None
@@ -356,3 +357,50 @@ async def test_async_added_to_hass_initial_refresh_error(monkeypatch):
                 pass
         elif hasattr(coro, "close"):
             coro.close()
+
+
+@pytest.mark.asyncio
+async def test_profiles_updated_triggers_immediate_refresh(monkeypatch):
+    sensor = DummySensor()
+    sensor._precomputed_store = DummyStore()
+    sensor._plans_store = DummyStore()
+
+    monkeypatch.setattr(
+        sensor_lifecycle.auto_switch_module, "auto_mode_switch_enabled", lambda _s: False
+    )
+    monkeypatch.setattr(
+        "homeassistant.helpers.event.async_track_time_change", lambda *_a, **_k: None
+    )
+
+    dispatcher_callbacks = []
+
+    def _connect(_hass, _signal, callback):
+        dispatcher_callbacks.append(callback)
+        return lambda: None
+
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.battery_forecast.sensors.sensor_lifecycle.async_dispatcher_connect",
+        _connect,
+    )
+
+    async def _sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(sensor_lifecycle.asyncio, "sleep", _sleep)
+
+    await sensor_lifecycle.async_added_to_hass(sensor)
+
+    assert sensor.hass.created
+    initial_refresh = sensor.hass.created.pop(0)
+    await initial_refresh
+    assert sensor._update_calls == 1
+
+    assert dispatcher_callbacks
+    await dispatcher_callbacks[0]()
+
+    assert sensor.hass.created
+    profiles_refresh = sensor.hass.created.pop(0)
+    await profiles_refresh
+
+    assert sensor._profiles_dirty is True
+    assert sensor._update_calls == 2

--- a/tests/test_sensor_setup_entry.py
+++ b/tests/test_sensor_setup_entry.py
@@ -50,6 +50,7 @@ class DummySensor:
         self.entity_id = "sensor.oig_123_dummy"
         self.device_info = {"identifiers": {("oig_cloud", "123")}}
         self.unique_id = "dummy"
+        self._attr_has_entity_name = True
 
 
 @pytest.mark.asyncio
@@ -169,6 +170,17 @@ async def test_sensor_async_setup_entry(monkeypatch):
 
     assert added
     assert entry.options.get("box_id") == "123"
+    assert all(getattr(entity, "_attr_has_entity_name", None) is False for entity in added)
+
+
+def test_apply_legacy_entity_naming_sets_short_name_mode():
+    first = SimpleNamespace(entity_id="sensor.one", _attr_has_entity_name=True)
+    second = SimpleNamespace(entity_id="sensor.two")
+
+    sensor_module._apply_legacy_entity_naming([first, second])
+
+    assert first._attr_has_entity_name is False
+    assert second._attr_has_entity_name is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove the battery-forecast startup wait and move forecast/statistics/precompute work onto background tasks so integration setup no longer blocks Home Assistant startup
- trigger an immediate forecast refresh when adaptive load profiles arrive after startup, avoiding stale planner data until the next 15-minute tick
- preserve legacy short OIG entity names for new entities and migrate existing registry entries to explicit short names, then bump the integration to 2.3.11 with changelog notes

## Testing
- `/repos/oig-cloud/.venv/bin/python -m pytest tests/test_sensor_lifecycle.py tests/test_precompute.py tests/test_entities_statistics_sensor.py tests/test_sensor_setup_entry.py tests/test_boiler_switch_wrapper.py tests/test_init_setup_entry.py`
