### PR TITLE
fix: stabilize startup and local telemetry updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.11] - 2026-04-01
+## [2.3.12] - 2026-04-03
 
 ### Fixed
+- Local telemetry updates now coalesce coordinator snapshot publishes, preventing websocket backlog storms and HA resource spikes in local/proxy mode.
+- OIG Cloud startup now hydrates coordinator cache first and defers non-critical sensor registration/background setup, reducing warm startup time to the ~5 second target range.
 - Battery forecast setup no longer waits for adaptive load profiles during startup, and related precompute/statistics restore work now runs in the background so Home Assistant setup is not blocked.
 - Existing OIG sensor and switch entities now migrate to explicit short registry names during setup, preventing newer Home Assistant versions from prepending device names to legacy entity labels.
+
+## [2.3.11] - 2026-04-01
 
 ## [2.3.10] - 2026-03-17
 

--- a/custom_components/oig_cloud/__init__.py
+++ b/custom_components/oig_cloud/__init__.py
@@ -1613,8 +1613,6 @@ async def async_setup_entry(
             },
         }
 
-        data_source_controller = None
-
         _setup_service_shield_data(hass, entry, coordinator, service_shield)
 
         # POZN: Plná migrace/cleanup device registry je riziková (může rozbít entity).

--- a/custom_components/oig_cloud/__init__.py
+++ b/custom_components/oig_cloud/__init__.py
@@ -886,6 +886,16 @@ async def _cleanup_invalid_empty_devices(
         _LOGGER.debug("Device registry cleanup failed (non-critical): %s", err)
 
 
+async def _schedule_invalid_device_cleanup(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    if getattr(hass, "loop", None) is None:
+        await _cleanup_invalid_empty_devices(hass, entry)
+        return
+
+    hass.async_create_task(_cleanup_invalid_empty_devices(hass, entry))
+
+
 def _migrate_enable_spot_prices_option(hass: HomeAssistant, entry: ConfigEntry) -> None:
     if "enable_spot_prices" not in entry.options:
         return
@@ -1055,32 +1065,67 @@ async def _init_session_manager_and_coordinator(
 
     state = get_data_source_state(hass, entry.entry_id)
     should_check_cloud_now = state.effective_mode == DATA_SOURCE_CLOUD_ONLY
-    if should_check_cloud_now:
-        _LOGGER.debug("Initial authentication via session manager")
-        await session_manager._ensure_auth()
-        await _ensure_live_data_enabled(oig_api)
-    else:
+
+    coordinator = OigCloudCoordinator(
+        hass, session_manager, standard_scan_interval, extended_scan_interval, entry
+    )
+    startup_cache_loaded = False
+    try:
+        startup_cache_loaded = await coordinator.async_hydrate_startup_cache()
+    except Exception as err:
+        _LOGGER.debug("Coordinator startup cache hydrate failed: %s", err)
+
+    has_box_id = False
+    try:
+        box_id = entry.options.get("box_id")
+        has_box_id = isinstance(box_id, str) and box_id.isdigit()
+    except Exception:
+        has_box_id = False
+
+    can_defer_cloud_refresh = startup_cache_loaded
+
+    if not should_check_cloud_now:
         _LOGGER.info(
             "Local telemetry mode active (configured=%s, local_ok=%s) – skipping initial cloud authentication and live-data check",
             state.configured_mode,
             state.local_available,
         )
 
-    coordinator = OigCloudCoordinator(
-        hass, session_manager, standard_scan_interval, extended_scan_interval, entry
-    )
-    _LOGGER.debug("Waiting for initial coordinator data...")
-    entry_state = getattr(entry, "state", None)
-    if entry_state == ConfigEntryState.SETUP_IN_PROGRESS:
-        await coordinator.async_config_entry_first_refresh()
-    elif hasattr(coordinator, "async_refresh"):
-        await coordinator.async_refresh()
-    else:
-        await coordinator.async_config_entry_first_refresh()
-    if coordinator.data is None:
+    _LOGGER.debug("Priming coordinator startup data...")
+    try:
+        entry_state = getattr(entry, "state", None)
+        if can_defer_cloud_refresh:
+            _LOGGER.info(
+                "Startup using cached coordinator state; deferring initial refresh "
+                "(cloud_now=%s, has_box_id=%s)",
+                should_check_cloud_now,
+                has_box_id,
+            )
+        elif (
+            not should_check_cloud_now
+            and entry_state != ConfigEntryState.SETUP_IN_PROGRESS
+            and hasattr(coordinator, "async_refresh")
+        ):
+            await coordinator.async_refresh()
+        else:
+            await coordinator.async_config_entry_first_refresh()
+    except Exception as err:
+        if (should_check_cloud_now and not can_defer_cloud_refresh) and coordinator.data is None:
+            _LOGGER.error("Initial coordinator refresh failed without cached data: %s", err)
+            raise ConfigEntryNotReady("No data received from OIG Cloud API") from err
+        _LOGGER.warning(
+            "Initial coordinator refresh failed but startup will continue with cached/local data: %s",
+            err,
+        )
+
+    if (should_check_cloud_now and not can_defer_cloud_refresh) and coordinator.data is None:
         _LOGGER.error("Failed to get initial data from coordinator")
         raise ConfigEntryNotReady("No data received from OIG Cloud API")
-    _LOGGER.debug("Coordinator data received: %s devices", len(coordinator.data))
+
+    if isinstance(coordinator.data, dict):
+        _LOGGER.debug("Coordinator startup data ready: %s devices", len(coordinator.data))
+    else:
+        _LOGGER.debug("Coordinator startup data not yet available; continuing setup")
 
     try:
         options = dict(entry.options)
@@ -1259,7 +1304,9 @@ async def _init_boiler_coordinator(
         if isinstance(box_id, str) and box_id.isdigit():
             boiler_config["box_id"] = box_id
         coordinator = BoilerCoordinator(hass, boiler_config)
+
         await coordinator.async_config_entry_first_refresh()
+
         _LOGGER.info("Boiler coordinator successfully initialized")
         return coordinator
     except Exception as err:
@@ -1291,6 +1338,7 @@ async def _init_balancing_manager(
         box_id = _resolve_entry_box_id(entry, coordinator)
         if not box_id:
             _LOGGER.warning("oig_cloud: No box_id available for BalancingManager")
+            return None
 
         storage_path = hass.config.path(".storage")
         balancing_manager = BalancingManager(hass, box_id, storage_path, entry)
@@ -1376,6 +1424,95 @@ async def _start_data_source_controller(
         return None
 
 
+async def _complete_entry_startup(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: OigCloudCoordinator,
+    session_manager: Any,
+    service_shield: Any | None,
+    telemetry_store: Any | None,
+    battery_prediction_enabled: bool,
+) -> None:
+    try:
+        state = get_data_source_state(hass, entry.entry_id)
+        should_check_cloud_now = state.effective_mode == DATA_SOURCE_CLOUD_ONLY
+
+        if should_check_cloud_now:
+            _LOGGER.info("Background startup: ensuring cloud auth and live-data access")
+            await session_manager._ensure_auth()
+            await _ensure_live_data_enabled(session_manager.api)
+            if hasattr(coordinator, "async_refresh"):
+                await coordinator.async_refresh()
+            else:
+                await coordinator.async_config_entry_first_refresh()
+
+        notification_manager = await _init_notification_manager(
+            hass, entry, coordinator, session_manager, service_shield
+        )
+        hass.data[DOMAIN][entry.entry_id]["notification_manager"] = notification_manager
+
+        balancing_manager = await _init_balancing_manager(
+            hass, entry, coordinator, battery_prediction_enabled
+        )
+        hass.data[DOMAIN][entry.entry_id]["balancing_manager"] = balancing_manager
+        if balancing_manager:
+            forecast_sensors = hass.data[DOMAIN][entry.entry_id].get(
+                "battery_forecast_sensors"
+            )
+            if isinstance(forecast_sensors, list) and forecast_sensors:
+                try:
+                    balancing_manager.set_forecast_sensor(forecast_sensors[0])
+                    balancing_manager.set_coordinator(coordinator)
+                except Exception as err:
+                    _LOGGER.debug(
+                        "Deferred BalancingManager forecast sensor wiring failed: %s",
+                        err,
+                    )
+
+        data_source_controller = await _start_data_source_controller(
+            hass, entry, coordinator, telemetry_store
+        )
+        if data_source_controller:
+            hass.data[DOMAIN][entry.entry_id][
+                "data_source_controller"
+            ] = data_source_controller
+
+        _LOGGER.info("Background startup completion finished for entry %s", entry.entry_id)
+    except Exception as err:
+        _LOGGER.warning(
+            "Background startup completion failed for entry %s: %s",
+            entry.entry_id,
+            err,
+            exc_info=True,
+        )
+
+
+async def _schedule_entry_startup_completion(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: OigCloudCoordinator,
+    session_manager: Any,
+    service_shield: Any | None,
+    telemetry_store: Any | None,
+    battery_prediction_enabled: bool,
+) -> None:
+    coro = _complete_entry_startup(
+        hass,
+        entry,
+        coordinator,
+        session_manager,
+        service_shield,
+        telemetry_store,
+        battery_prediction_enabled,
+    )
+
+    if getattr(hass, "loop", None) is None:
+        await coro
+        return
+
+    hass.async_create_task(coro)
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> bool:  # noqa: C901
@@ -1427,9 +1564,7 @@ async def async_setup_entry(
             extended_scan_interval,
         )
 
-        notification_manager = await _init_notification_manager(
-            hass, entry, coordinator, session_manager, service_shield
-        )
+        notification_manager = None
 
         solar_forecast = _init_solar_forecast(entry)
 
@@ -1451,9 +1586,7 @@ async def async_setup_entry(
         battery_prediction_enabled = entry.options.get(
             "enable_battery_prediction", False
         )
-        balancing_manager = await _init_balancing_manager(
-            hass, entry, coordinator, battery_prediction_enabled
-        )
+        balancing_manager = None
 
         telemetry_store = _init_telemetry_store(hass, entry, coordinator)
 
@@ -1480,13 +1613,7 @@ async def async_setup_entry(
             },
         }
 
-        data_source_controller = await _start_data_source_controller(
-            hass, entry, coordinator, telemetry_store
-        )
-        if data_source_controller:
-            hass.data[DOMAIN][entry.entry_id][
-                "data_source_controller"
-            ] = data_source_controller
+        data_source_controller = None
 
         _setup_service_shield_data(hass, entry, coordinator, service_shield)
 
@@ -1500,7 +1627,7 @@ async def async_setup_entry(
 
         # Targeted cleanup for stale/invalid devices (e.g., 'spot_prices', 'unknown')
         # that can be left behind after unique_id/device_id stabilization.
-        await _cleanup_invalid_empty_devices(hass, entry)
+        await _schedule_invalid_device_cleanup(hass, entry)
         await _migrate_entity_names_to_legacy_short_names(hass, entry)
 
         await _sync_dashboard_panel(hass, entry, dashboard_enabled)
@@ -1512,6 +1639,16 @@ async def async_setup_entry(
         _register_api_endpoints(hass, boiler_coordinator)
 
         _setup_service_shield_monitoring(hass, entry, service_shield)
+
+        await _schedule_entry_startup_completion(
+            hass,
+            entry,
+            coordinator,
+            session_manager,
+            service_shield,
+            telemetry_store,
+            battery_prediction_enabled,
+        )
 
         # OPRAVA: ODSTRANĚNÍ duplicitní registrace služeb - způsobovala přepsání správného schématu
         # Služby se už registrovaly výše v async_setup_entry_services_with_shield

--- a/custom_components/oig_cloud/core/coordinator.py
+++ b/custom_components/oig_cloud/core/coordinator.py
@@ -194,19 +194,7 @@ class OigCloudCoordinator(DataUpdateCoordinator):
         This makes entities render immediately with last-known values (retain-like behavior),
         while the coordinator is still doing the first network/local refresh.
         """
-        if self._cache_store is not None:
-            try:
-                cached = await self._cache_store.async_load()
-                cached_data = cached.get("data") if isinstance(cached, dict) else None
-                if isinstance(cached_data, dict) and cached_data:
-                    self.data = cached_data
-                    self.last_update_success = True
-                    _LOGGER.debug(
-                        "Loaded cached coordinator data (%d keys) before first refresh",
-                        len(cached_data),
-                    )
-            except Exception as err:
-                _LOGGER.debug("Failed to load coordinator cache: %s", err)
+        await self.async_hydrate_startup_cache()
 
         try:
             await super().async_config_entry_first_refresh()
@@ -220,6 +208,28 @@ class OigCloudCoordinator(DataUpdateCoordinator):
                 )
                 return
             raise
+
+    async def async_hydrate_startup_cache(self) -> bool:
+        if self._cache_store is None:
+            return False
+
+        try:
+            cached = await self._cache_store.async_load()
+        except Exception as err:
+            _LOGGER.debug("Failed to load coordinator cache: %s", err)
+            return False
+
+        cached_data = cached.get("data") if isinstance(cached, dict) else None
+        if not isinstance(cached_data, dict) or not cached_data:
+            return False
+
+        self.data = cached_data
+        self.last_update_success = True
+        _LOGGER.debug(
+            "Loaded cached coordinator data (%d keys) before refresh",
+            len(cached_data),
+        )
+        return True
 
     def _prune_for_cache(self, value: Any, *, _depth: int = 0) -> Any:
         """Reduce payload size before saving to HA storage."""

--- a/custom_components/oig_cloud/core/data_source.py
+++ b/custom_components/oig_cloud/core/data_source.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -23,6 +24,7 @@ DATA_SOURCE_LOCAL_ONLY = "local_only"
 DEFAULT_DATA_SOURCE_MODE = DATA_SOURCE_CLOUD_ONLY
 DEFAULT_PROXY_STALE_MINUTES = 10
 DEFAULT_LOCAL_EVENT_DEBOUNCE_MS = 300
+DEFAULT_LOCAL_PAYLOAD_PUBLISH_INTERVAL_S = 5.0
 
 # Fired on hass.bus when effective data source changes for a config entry.
 # Payload: {"entry_id": str, "configured_mode": str, "effective_mode": str, "local_available": bool, "reason": str}
@@ -423,9 +425,12 @@ class DataSourceController:
         self.coordinator = coordinator
         self.telemetry_store = telemetry_store
 
-        self._unsubs: list[callable] = []
-        self._last_local_entity_update: Optional[dt_util.dt.datetime] = None
+        self._unsubs: list[Callable[[], None]] = []
+        self._last_local_entity_update: Optional[datetime] = None
         self._pending_local_entities: set[str] = set()
+        self._pending_snapshot_publish = False
+        self._snapshot_publish_handle: Optional[Any] = None
+        self._last_snapshot_publish_monotonic: Optional[float] = None
         self._debouncer = Debouncer(
             hass,
             _LOGGER,
@@ -444,9 +449,14 @@ class DataSourceController:
                 get_configured_mode(self.entry) != DATA_SOURCE_CLOUD_ONLY
                 and self.telemetry_store
             ):
+                state = get_data_source_state(self.hass, self.entry.entry_id)
                 did_seed = self.telemetry_store.seed_from_existing_local_states()
-                if did_seed and getattr(
-                    self.coordinator, "async_set_updated_data", None
+                if (
+                    did_seed
+                    and state.effective_mode != DATA_SOURCE_CLOUD_ONLY
+                    and getattr(
+                        self.coordinator, "async_set_updated_data", None
+                    )
                 ):
                     snap = self.telemetry_store.get_snapshot()
                     self.coordinator.async_set_updated_data(snap.payload)
@@ -492,6 +502,12 @@ class DataSourceController:
 
     async def async_stop(self) -> None:
         await asyncio.sleep(0)
+        if self._snapshot_publish_handle is not None:
+            try:
+                self._snapshot_publish_handle.cancel()
+            except Exception as err:
+                _LOGGER.debug("Failed to cancel snapshot publish handle: %s", err)
+            self._snapshot_publish_handle = None
         for unsub in self._unsubs:
             try:
                 unsub()
@@ -588,13 +604,75 @@ class DataSourceController:
                 self._pending_local_entities.clear()
                 if pending:
                     changed = self.telemetry_store.apply_local_events(pending)
-                    if changed and getattr(
-                        self.coordinator, "async_set_updated_data", None
-                    ):
-                        snap = self.telemetry_store.get_snapshot()
-                        self.coordinator.async_set_updated_data(snap.payload)
+                    if changed:
+                        self._schedule_snapshot_publish()
         except Exception as err:
             _LOGGER.debug("Failed to handle local telemetry event: %s", err)
+
+    @callback
+    def _schedule_snapshot_publish(self) -> None:
+        if not (
+            self.telemetry_store
+            and self.coordinator
+            and getattr(self.coordinator, "async_set_updated_data", None)
+        ):
+            return
+
+        self._pending_snapshot_publish = True
+
+        now = self._monotonic_time()
+        last = self._last_snapshot_publish_monotonic
+        if last is None or (now - last) >= DEFAULT_LOCAL_PAYLOAD_PUBLISH_INTERVAL_S:
+            self._publish_pending_snapshot()
+            return
+
+        if self._snapshot_publish_handle is not None:
+            return
+
+        delay = max(0.0, DEFAULT_LOCAL_PAYLOAD_PUBLISH_INTERVAL_S - (now - last))
+        loop = getattr(self.hass, "loop", None)
+        if loop is None or not hasattr(loop, "call_later"):
+            self._publish_pending_snapshot()
+            return
+
+        self._snapshot_publish_handle = loop.call_later(
+            delay, self._publish_pending_snapshot
+        )
+
+    @callback
+    def _publish_pending_snapshot(self) -> None:
+        self._snapshot_publish_handle = None
+        if not self._pending_snapshot_publish:
+            return
+        if not (
+            self.telemetry_store
+            and self.coordinator
+            and getattr(self.coordinator, "async_set_updated_data", None)
+        ):
+            self._pending_snapshot_publish = False
+            return
+
+        try:
+            state = get_data_source_state(self.hass, self.entry.entry_id)
+            if state.effective_mode == DATA_SOURCE_CLOUD_ONLY:
+                self._pending_snapshot_publish = False
+                return
+        except Exception as err:
+            _LOGGER.debug("Failed to re-check data source state before publish: %s", err)
+
+        self._pending_snapshot_publish = False
+        self._last_snapshot_publish_monotonic = self._monotonic_time()
+        snap = self.telemetry_store.get_snapshot()
+        self.coordinator.async_set_updated_data(snap.payload)
+
+    def _monotonic_time(self) -> float:
+        loop = getattr(self.hass, "loop", None)
+        if loop is not None and hasattr(loop, "time"):
+            try:
+                return float(loop.time())
+            except Exception:
+                pass
+        return time.monotonic()
 
     @callback
     def _update_state(self, force: bool = False) -> tuple[bool, bool]:

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.11",
+  "version": "2.3.12",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/sensor.py
+++ b/custom_components/oig_cloud/sensor.py
@@ -1448,25 +1448,85 @@ def _apply_legacy_entity_naming(entities: List[Any]) -> None:
 
 def _schedule_deferred_sensor_registration(
     hass: HomeAssistant,
+    entry_id: str,
     async_add_entities: AddEntitiesCallback,
     deferred_factories: List[Callable[[], List[Any]]],
 ) -> None:
     if not deferred_factories:
         return
 
+    def _entry_still_loaded() -> bool:
+        domain_data = hass.data.get(DOMAIN)
+        return isinstance(domain_data, dict) and entry_id in domain_data
+
+    def _build_deferred_sensors() -> List[Any]:
+        deferred_sensors: List[Any] = []
+        for factory in deferred_factories:
+            try:
+                deferred_sensors.extend(factory())
+            except Exception as err:
+                _LOGGER.warning(
+                    "Deferred sensor factory failed for entry %s during setup: %s",
+                    entry_id,
+                    err,
+                    exc_info=True,
+                )
+        return deferred_sensors
+
     async def _register_later() -> None:
         await asyncio.sleep(0)
-        deferred_sensors: List[Any] = []
-        for factory in deferred_factories:
-            deferred_sensors.extend(factory())
+        if not _entry_still_loaded():
+            _LOGGER.debug(
+                "Skipping deferred sensor registration because entry %s is no longer loaded",
+                entry_id,
+            )
+            return
+
+        deferred_sensors = _build_deferred_sensors()
+
+        if not _entry_still_loaded():
+            _LOGGER.debug(
+                "Skipping deferred sensor registration because entry %s was unloaded",
+                entry_id,
+            )
+            return
+
+        if not deferred_sensors:
+            return
+
+        try:
+            _register_all_sensors(async_add_entities, deferred_sensors)
+        except Exception as err:
+            _LOGGER.warning(
+                "Deferred sensor registration failed for entry %s: %s",
+                entry_id,
+                err,
+                exc_info=True,
+            )
             await asyncio.sleep(0)
-        _register_all_sensors(async_add_entities, deferred_sensors)
 
     if getattr(hass, "loop", None) is None:
-        deferred_sensors: List[Any] = []
-        for factory in deferred_factories:
-            deferred_sensors.extend(factory())
-        _register_all_sensors(async_add_entities, deferred_sensors)
+        if not _entry_still_loaded():
+            _LOGGER.debug(
+                "Skipping deferred sensor registration because entry %s is no longer loaded",
+                entry_id,
+            )
+            return
+
+        deferred_sensors = _build_deferred_sensors()
+
+        if not _entry_still_loaded() or not deferred_sensors:
+            return
+
+        try:
+            _register_all_sensors(async_add_entities, deferred_sensors)
+        except Exception as err:
+            _LOGGER.warning(
+                "Deferred sensor registration failed for entry %s: %s",
+                entry_id,
+                err,
+                exc_info=True,
+            )
         return
 
     hass.async_create_task(_register_later())
@@ -1643,7 +1703,9 @@ async def async_setup_entry(  # noqa: C901
     # PERFORMANCE FIX: Register all sensors at once instead of 17 separate calls
     # ================================================================
     _register_all_sensors(async_add_entities, core_sensors)
-    _schedule_deferred_sensor_registration(hass, async_add_entities, deferred_factories)
+    _schedule_deferred_sensor_registration(
+        hass, entry.entry_id, async_add_entities, deferred_factories
+    )
 
     _LOGGER.info("OIG Cloud sensor setup completed")
 

--- a/custom_components/oig_cloud/sensor.py
+++ b/custom_components/oig_cloud/sensor.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -878,6 +878,8 @@ def _create_battery_prediction_sensors(
     _LOGGER.info(f"Battery prediction enabled: {battery_prediction_enabled}")
     if not battery_prediction_enabled:
         _LOGGER.info("Battery prediction sensors disabled - skipping creation")
+        if DOMAIN in hass.data and entry.entry_id in hass.data[DOMAIN]:
+            hass.data[DOMAIN][entry.entry_id]["battery_forecast_sensors"] = []
         return []
 
     try:
@@ -971,6 +973,9 @@ def _connect_balancing_manager(
     if not battery_forecast_sensors:
         return
     try:
+        hass.data[DOMAIN][entry.entry_id]["battery_forecast_sensors"] = (
+            battery_forecast_sensors
+        )
         balancing_manager = hass.data[DOMAIN][entry.entry_id].get("balancing_manager")
         if balancing_manager:
             forecast_sensor = battery_forecast_sensors[0]
@@ -1441,6 +1446,32 @@ def _apply_legacy_entity_naming(entities: List[Any]) -> None:
             )
 
 
+def _schedule_deferred_sensor_registration(
+    hass: HomeAssistant,
+    async_add_entities: AddEntitiesCallback,
+    deferred_factories: List[Callable[[], List[Any]]],
+) -> None:
+    if not deferred_factories:
+        return
+
+    async def _register_later() -> None:
+        await asyncio.sleep(0)
+        deferred_sensors: List[Any] = []
+        for factory in deferred_factories:
+            deferred_sensors.extend(factory())
+            await asyncio.sleep(0)
+        _register_all_sensors(async_add_entities, deferred_sensors)
+
+    if getattr(hass, "loop", None) is None:
+        deferred_sensors: List[Any] = []
+        for factory in deferred_factories:
+            deferred_sensors.extend(factory())
+        _register_all_sensors(async_add_entities, deferred_sensors)
+        return
+
+    hass.async_create_task(_register_later())
+
+
 async def async_setup_entry(  # noqa: C901
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -1450,8 +1481,8 @@ async def async_setup_entry(  # noqa: C901
 
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
-    # PERFORMANCE FIX: Collect all sensors in one list instead of calling async_add_entities 17 times
-    all_sensors: List[Any] = []
+    core_sensors: List[Any] = []
+    deferred_factories: List[Callable[[], List[Any]]] = []
 
     _log_coordinator_data_status(coordinator)
 
@@ -1479,7 +1510,7 @@ async def async_setup_entry(  # noqa: C901
     # ================================================================
     # SECTION 0: DATA SOURCE STATE SENSOR (always on)
     # ================================================================
-    all_sensors.extend(_register_data_source_sensor(hass, coordinator, entry))
+    core_sensors.extend(_register_data_source_sensor(hass, coordinator, entry))
 
     await asyncio.sleep(0)
 
@@ -1490,7 +1521,7 @@ async def async_setup_entry(  # noqa: C901
     # Device: main_device_info (OIG Cloud {box_id})
     # Třída: OigCloudDataSensor
     # ================================================================
-    all_sensors.extend(_create_basic_sensors(coordinator))
+    core_sensors.extend(_create_basic_sensors(coordinator))
     await asyncio.sleep(0)
 
     # ================================================================
@@ -1500,7 +1531,7 @@ async def async_setup_entry(  # noqa: C901
     # Device: main_device_info (OIG Cloud {box_id})
     # Třída: OigCloudComputedSensor
     # ================================================================
-    all_sensors.extend(_create_computed_sensors(coordinator))
+    core_sensors.extend(_create_computed_sensors(coordinator))
     await asyncio.sleep(0)
 
     # ================================================================
@@ -1510,7 +1541,7 @@ async def async_setup_entry(  # noqa: C901
     # Device: main_device_info (OIG Cloud {box_id})
     # Třída: OigCloudDataSensor (s extended=True)
     # ================================================================
-    all_sensors.extend(_create_extended_sensors(coordinator, entry))
+    deferred_factories.append(lambda: _create_extended_sensors(coordinator, entry))
     await asyncio.sleep(0)
 
     # ================================================================
@@ -1520,8 +1551,10 @@ async def async_setup_entry(  # noqa: C901
     # Device: analytics_device_info (Analytics & Predictions {box_id})
     # Třída: OigCloudStatisticsSensor
     # ================================================================
-    all_sensors.extend(
-        _create_statistics_sensors(hass, coordinator, entry, analytics_device_info)
+    deferred_factories.append(
+        lambda: _create_statistics_sensors(
+            hass, coordinator, entry, analytics_device_info
+        )
     )
     await asyncio.sleep(0)
 
@@ -1532,8 +1565,8 @@ async def async_setup_entry(  # noqa: C901
     # Device: analytics_device_info (Analytics & Predictions {box_id})
     # Třída: OigCloudSolarForecastSensor
     # ================================================================
-    all_sensors.extend(
-        _create_solar_forecast_sensors(
+    deferred_factories.append(
+        lambda: _create_solar_forecast_sensors(
             hass, coordinator, entry, analytics_device_info
         )
     )
@@ -1546,7 +1579,7 @@ async def async_setup_entry(  # noqa: C901
     # Device: shield_device_info (ServiceShield {box_id})
     # Třída: OigCloudShieldSensor
     # ================================================================
-    all_sensors.extend(_create_shield_sensors(coordinator))
+    core_sensors.extend(_create_shield_sensors(coordinator))
     await asyncio.sleep(0)
 
     # ================================================================
@@ -1556,7 +1589,7 @@ async def async_setup_entry(  # noqa: C901
     # Device: main_device_info (OIG Cloud {box_id})
     # Třída: OigCloudDataSensor (s notification=True)
     # ================================================================
-    all_sensors.extend(_create_notification_sensors(coordinator))
+    core_sensors.extend(_create_notification_sensors(coordinator))
     await asyncio.sleep(0)
 
     # ================================================================
@@ -1566,8 +1599,8 @@ async def async_setup_entry(  # noqa: C901
     # Device: analytics_device_info (Analytics & Predictions {box_id})
     # Třída: OigCloudBatteryForecastSensor
     # ================================================================
-    all_sensors.extend(
-        _create_battery_prediction_sensors(
+    deferred_factories.append(
+        lambda: _create_battery_prediction_sensors(
             hass, coordinator, entry, analytics_device_info
         )
     )
@@ -1580,8 +1613,8 @@ async def async_setup_entry(  # noqa: C901
     # Device: analytics_device_info (Analytics & Predictions {box_id})
     # Třídy: OigCloudAnalyticsSensor, SpotPrice15MinSensor, ExportPrice15MinSensor
     # ================================================================
-    all_sensors.extend(
-        _create_pricing_sensors(coordinator, entry, analytics_device_info)
+    deferred_factories.append(
+        lambda: _create_pricing_sensors(coordinator, entry, analytics_device_info)
     )
     await asyncio.sleep(0)
 
@@ -1592,8 +1625,8 @@ async def async_setup_entry(  # noqa: C901
     # Device: analytics_device_info (Analytics & Predictions {box_id})
     # Třída: OigCloudChmuSensor
     # ================================================================
-    all_sensors.extend(
-        _create_chmu_sensors(coordinator, entry, analytics_device_info)
+    deferred_factories.append(
+        lambda: _create_chmu_sensors(coordinator, entry, analytics_device_info)
     )
     await asyncio.sleep(0)
 
@@ -1604,12 +1637,13 @@ async def async_setup_entry(  # noqa: C901
     # Device: OIG Bojler (samostatné zařízení)
     # Třída: BoilerSensor* (13 senzorů)
     # ================================================================
-    all_sensors.extend(_create_boiler_sensors(hass, entry))
+    deferred_factories.append(lambda: _create_boiler_sensors(hass, entry))
 
     # ================================================================
     # PERFORMANCE FIX: Register all sensors at once instead of 17 separate calls
     # ================================================================
-    _register_all_sensors(async_add_entities, all_sensors)
+    _register_all_sensors(async_add_entities, core_sensors)
+    _schedule_deferred_sensor_registration(hass, async_add_entities, deferred_factories)
 
     _LOGGER.info("OIG Cloud sensor setup completed")
 

--- a/tests/test_data_source_controller.py
+++ b/tests/test_data_source_controller.py
@@ -44,13 +44,38 @@ class DummyBus:
 
 
 class DummyHass:
-    def __init__(self, states):
+    def __init__(self, states, loop=None):
         self.states = DummyStates(states)
         self.data = {module.DOMAIN: {}}
         self.bus = DummyBus()
+        self.loop = loop
 
     def async_create_task(self, _coro):
         return None
+
+
+class DummyHandle:
+    def __init__(self, delay, callback):
+        self.delay = delay
+        self.callback = callback
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class DummyLoop:
+    def __init__(self, now_time=0.0):
+        self.now_time = now_time
+        self.scheduled = []
+
+    def time(self):
+        return self.now_time
+
+    def call_later(self, delay, callback):
+        handle = DummyHandle(delay, callback)
+        self.scheduled.append(handle)
+        return handle
 
 
 def _make_entry(mode, box_id="123"):
@@ -240,7 +265,8 @@ def test_on_effective_mode_changed_handles_errors():
         )
     }
 
-    def _raise_fire(_event, _data):
+    def _raise_fire(event, data):
+        del event, data
         raise RuntimeError("fail")
 
     hass.bus.async_fire = _raise_fire
@@ -303,10 +329,158 @@ async def test_handle_local_event_updates_coordinator():
 
 
 @pytest.mark.asyncio
+async def test_handle_local_event_throttles_snapshot_publish():
+    now = dt_util.utcnow()
+    loop = DummyLoop(now_time=12.0)
+    hass = DummyHass([], loop=loop)
+    entry = _make_entry(module.DATA_SOURCE_LOCAL_ONLY)
+
+    class DummyStore:
+        def apply_local_events(self, _pending):
+            return True
+
+        def get_snapshot(self):
+            return SimpleNamespace(payload={"123": {"box_prms": {"mode": 1}}})
+
+    class DummyCoordinator:
+        def __init__(self):
+            self.updates = []
+
+        def async_set_updated_data(self, data):
+            self.updates.append(data)
+
+    controller = module.DataSourceController(
+        hass, entry, coordinator=DummyCoordinator(), telemetry_store=DummyStore()
+    )
+    controller._pending_local_entities = {"sensor.oig_local_123_ac_out"}
+    controller._last_snapshot_publish_monotonic = 10.0
+    hass.data[module.DOMAIN][entry.entry_id] = {
+        "data_source_state": module.DataSourceState(
+            configured_mode=module.DATA_SOURCE_LOCAL_ONLY,
+            effective_mode=module.DATA_SOURCE_LOCAL_ONLY,
+            local_available=True,
+            last_local_data=now,
+            reason="local_ok",
+        )
+    }
+
+    controller._update_state = lambda: (False, False)
+    await controller._handle_local_event()
+
+    assert controller.coordinator.updates == []
+    assert controller._pending_snapshot_publish is True
+    assert len(loop.scheduled) == 1
+    assert loop.scheduled[0].delay == pytest.approx(3.0)
+
+    loop.now_time = 15.0
+    loop.scheduled[0].callback()
+
+    assert controller.coordinator.updates == [{"123": {"box_prms": {"mode": 1}}}]
+    assert controller._pending_snapshot_publish is False
+
+
+def test_schedule_snapshot_publish_coalesces_pending_updates():
+    now = dt_util.utcnow()
+    loop = DummyLoop(now_time=12.0)
+    hass = DummyHass([], loop=loop)
+    entry = _make_entry(module.DATA_SOURCE_LOCAL_ONLY)
+
+    class DummyStore:
+        def get_snapshot(self):
+            return SimpleNamespace(payload={"123": {"box_prms": {"mode": 1}}})
+
+    class DummyCoordinator:
+        def __init__(self):
+            self.updates = []
+
+        def async_set_updated_data(self, data):
+            self.updates.append(data)
+
+    controller = module.DataSourceController(
+        hass, entry, coordinator=DummyCoordinator(), telemetry_store=DummyStore()
+    )
+    controller._last_snapshot_publish_monotonic = 10.0
+    hass.data[module.DOMAIN][entry.entry_id] = {
+        "data_source_state": module.DataSourceState(
+            configured_mode=module.DATA_SOURCE_LOCAL_ONLY,
+            effective_mode=module.DATA_SOURCE_LOCAL_ONLY,
+            local_available=True,
+            last_local_data=now,
+            reason="local_ok",
+        )
+    }
+
+    controller._schedule_snapshot_publish()
+    controller._schedule_snapshot_publish()
+
+    assert len(loop.scheduled) == 1
+    loop.now_time = 15.0
+    loop.scheduled[0].callback()
+    assert controller.coordinator.updates == [{"123": {"box_prms": {"mode": 1}}}]
+
+
+def test_publish_pending_snapshot_skips_when_effective_cloud(monkeypatch):
+    now = dt_util.utcnow()
+    loop = DummyLoop(now_time=12.0)
+    hass = DummyHass([], loop=loop)
+    entry = _make_entry(module.DATA_SOURCE_LOCAL_ONLY)
+
+    class DummyStore:
+        def get_snapshot(self):
+            return SimpleNamespace(payload={"123": {"box_prms": {"mode": 1}}})
+
+    class DummyCoordinator:
+        def __init__(self):
+            self.updates = []
+
+        def async_set_updated_data(self, data):
+            self.updates.append(data)
+
+    controller = module.DataSourceController(
+        hass, entry, coordinator=DummyCoordinator(), telemetry_store=DummyStore()
+    )
+    controller._pending_snapshot_publish = True
+
+    monkeypatch.setattr(
+        module,
+        "get_data_source_state",
+        lambda *_a, **_k: module.DataSourceState(
+            configured_mode=module.DATA_SOURCE_LOCAL_ONLY,
+            effective_mode=module.DATA_SOURCE_CLOUD_ONLY,
+            local_available=False,
+            last_local_data=now,
+            reason="cloud_only",
+        ),
+    )
+
+    controller._publish_pending_snapshot()
+
+    assert controller.coordinator.updates == []
+    assert controller._pending_snapshot_publish is False
+
+
+@pytest.mark.asyncio
+async def test_async_stop_cancels_snapshot_publish_handle():
+    loop = DummyLoop(now_time=12.0)
+    hass = DummyHass([], loop=loop)
+    entry = _make_entry(module.DATA_SOURCE_LOCAL_ONLY)
+    controller = module.DataSourceController(hass, entry, coordinator=None)
+
+    handle = DummyHandle(1.0, lambda: None)
+    controller._snapshot_publish_handle = handle
+
+    await controller.async_stop()
+
+    assert handle.cancelled is True
+    assert controller._snapshot_publish_handle is None
+
+
+@pytest.mark.asyncio
 async def test_async_start_fallback_listeners(monkeypatch):
     now = dt_util.utcnow()
     states = [
         DummyState(module.PROXY_LAST_DATA_ENTITY_ID, now.isoformat(), last_updated=now),
+        DummyState(module.PROXY_BOX_ID_ENTITY_ID, "123", last_updated=now),
     ]
     hass = DummyHass(states)
     entry = _make_entry(module.DATA_SOURCE_LOCAL_ONLY)
@@ -335,6 +509,52 @@ async def test_async_start_fallback_listeners(monkeypatch):
     await controller.async_start()
 
     assert controller.coordinator.updated == {"123": {"box_prms": {"mode": 1}}}
+
+
+@pytest.mark.asyncio
+async def test_async_start_seed_skips_publish_when_effective_cloud(monkeypatch):
+    now = dt_util.utcnow()
+    states = [
+        DummyState(module.PROXY_LAST_DATA_ENTITY_ID, now.isoformat(), last_updated=now),
+    ]
+    hass = DummyHass(states)
+    entry = _make_entry(module.DATA_SOURCE_LOCAL_ONLY)
+
+    class DummyStore:
+        def seed_from_existing_local_states(self):
+            return True
+
+        def get_snapshot(self):
+            return SimpleNamespace(payload={"123": {"box_prms": {"mode": 1}}})
+
+    class DummyCoordinator:
+        def __init__(self):
+            self.updated = None
+
+        def async_set_updated_data(self, data):
+            self.updated = data
+
+    controller = module.DataSourceController(
+        hass, entry, coordinator=DummyCoordinator(), telemetry_store=DummyStore()
+    )
+
+    monkeypatch.setattr(module, "_async_track_state_change_event", None)
+    monkeypatch.setattr(module, "_async_track_time_interval", None)
+    monkeypatch.setattr(
+        module,
+        "get_data_source_state",
+        lambda *_a, **_k: module.DataSourceState(
+            configured_mode=module.DATA_SOURCE_LOCAL_ONLY,
+            effective_mode=module.DATA_SOURCE_CLOUD_ONLY,
+            local_available=False,
+            last_local_data=now,
+            reason="cloud_only",
+        ),
+    )
+
+    await controller.async_start()
+
+    assert controller.coordinator.updated is None
 
 
 def test_init_data_source_state_entry_options_error():

--- a/tests/test_init_setup_entry.py
+++ b/tests/test_init_setup_entry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import Any, Awaitable, Callable, cast
 
 import pytest
 
@@ -37,11 +38,22 @@ class DummyHass:
         self.data = {}
         self.states = SimpleNamespace(get=lambda _eid: None)
         self.config_entries = DummyConfigEntries()
-        self.loop = None
+        self.loop: object | None = None
+        self.config: Any | None = None
 
     def async_create_task(self, coro):
         if hasattr(coro, "close"):
             coro.close()
+
+
+class TrackingHass(DummyHass):
+    def __init__(self):
+        super().__init__()
+        self.created_tasks: list[Awaitable[Any]] = []
+
+    def async_create_task(self, coro):
+        self.created_tasks.append(coro)
+        return coro
 
 
 class DummyEntry:
@@ -50,6 +62,7 @@ class DummyEntry:
         self.data = data or {}
         self.options = options or {}
         self.title = title
+        self.state: Any = None
         self._unload = []
         self._listener = None
 
@@ -114,10 +127,13 @@ class DummyCoordinator:
 
 
 class DummyCoordinatorWithRefresh(DummyCoordinator):
+    startup_cache_loaded = False
+
     def __init__(self, hass, session_manager, *_args, **_kwargs):
         super().__init__(hass, session_manager, *_args, **_kwargs)
         self.first_refresh_called = False
         self.refresh_called = False
+        self.hydrate_called = False
 
     async def async_config_entry_first_refresh(self):
         self.first_refresh_called = True
@@ -126,6 +142,10 @@ class DummyCoordinatorWithRefresh(DummyCoordinator):
     async def async_refresh(self):
         self.refresh_called = True
         return None
+
+    async def async_hydrate_startup_cache(self):
+        self.hydrate_called = True
+        return self.startup_cache_loaded
 
 
 class DummyDataSourceController:
@@ -183,6 +203,218 @@ class RaisingOptions(dict):
         if key == "box_id":
             raise RuntimeError("boom")
         return super().get(key, default)
+
+
+class TrackingCoordinator:
+    def __init__(self):
+        self.refresh_called = False
+        self.first_refresh_called = False
+
+    async def async_refresh(self):
+        self.refresh_called = True
+
+    async def async_config_entry_first_refresh(self):
+        self.first_refresh_called = True
+
+
+class TrackingBalancingManager:
+    def __init__(self):
+        self.forecast_sensor = None
+        self.coordinator = None
+
+    def set_forecast_sensor(self, sensor):
+        self.forecast_sensor = sensor
+
+    def set_coordinator(self, coordinator):
+        self.coordinator = coordinator
+
+
+AsyncEventCallback = Callable[[Any], Awaitable[Any]]
+
+
+@pytest.mark.asyncio
+async def test_complete_entry_startup_cloud_initializes_deferred_components(
+    monkeypatch,
+):
+    hass = DummyHass()
+    entry = DummyEntry()
+    coordinator = TrackingCoordinator()
+    session_manager = DummySessionManager(DummyApi())
+    balancing_manager = TrackingBalancingManager()
+    controller = object()
+    live_data_checked = {"called": False}
+
+    hass.data[DOMAIN] = {
+        entry.entry_id: {"battery_forecast_sensors": ["forecast-sensor"]}
+    }
+
+    async def fake_live_data_check(_api):
+        live_data_checked["called"] = True
+
+    async def fake_init_notification_manager(*_args, **_kwargs):
+        return "notification-manager"
+
+    async def fake_init_balancing_manager(*_args, **_kwargs):
+        return balancing_manager
+
+    async def fake_start_data_source_controller(*_args, **_kwargs):
+        return controller
+
+    monkeypatch.setattr(
+        init_module,
+        "get_data_source_state",
+        lambda *_a, **_k: SimpleNamespace(
+            effective_mode=init_module.DATA_SOURCE_CLOUD_ONLY,
+        ),
+    )
+    monkeypatch.setattr(init_module, "_ensure_live_data_enabled", fake_live_data_check)
+    monkeypatch.setattr(
+        init_module,
+        "_init_notification_manager",
+        fake_init_notification_manager,
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_init_balancing_manager",
+        fake_init_balancing_manager,
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_start_data_source_controller",
+        fake_start_data_source_controller,
+    )
+
+    await init_module._complete_entry_startup(
+        hass,
+        entry,
+        coordinator,
+        session_manager,
+        service_shield=None,
+        telemetry_store=None,
+        battery_prediction_enabled=True,
+    )
+
+    assert session_manager.ensure_called is True
+    assert live_data_checked["called"] is True
+    assert coordinator.refresh_called is True
+    assert coordinator.first_refresh_called is False
+    assert hass.data[DOMAIN][entry.entry_id]["notification_manager"] == "notification-manager"
+    assert hass.data[DOMAIN][entry.entry_id]["balancing_manager"] is balancing_manager
+    assert hass.data[DOMAIN][entry.entry_id]["data_source_controller"] is controller
+    assert balancing_manager.forecast_sensor == "forecast-sensor"
+    assert balancing_manager.coordinator is coordinator
+
+
+@pytest.mark.asyncio
+async def test_complete_entry_startup_local_skips_cloud_refresh(monkeypatch):
+    hass = DummyHass()
+    entry = DummyEntry()
+    coordinator = TrackingCoordinator()
+    session_manager = DummySessionManager(DummyApi())
+
+    hass.data[DOMAIN] = {entry.entry_id: {}}
+
+    async def fake_init_notification_manager(*_args, **_kwargs):
+        return None
+
+    async def fake_init_balancing_manager(*_args, **_kwargs):
+        return None
+
+    async def fake_start_data_source_controller(*_args, **_kwargs):
+        return None
+
+    async def fail_live_data_check(_api):
+        raise AssertionError("live-data check should be skipped in local mode")
+
+    monkeypatch.setattr(
+        init_module,
+        "get_data_source_state",
+        lambda *_a, **_k: SimpleNamespace(effective_mode="local_only"),
+    )
+    monkeypatch.setattr(init_module, "_ensure_live_data_enabled", fail_live_data_check)
+    monkeypatch.setattr(
+        init_module,
+        "_init_notification_manager",
+        fake_init_notification_manager,
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_init_balancing_manager",
+        fake_init_balancing_manager,
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_start_data_source_controller",
+        fake_start_data_source_controller,
+    )
+
+    await init_module._complete_entry_startup(
+        hass,
+        entry,
+        coordinator,
+        session_manager,
+        service_shield=None,
+        telemetry_store=None,
+        battery_prediction_enabled=False,
+    )
+
+    assert session_manager.ensure_called is False
+    assert coordinator.refresh_called is False
+    assert coordinator.first_refresh_called is False
+
+
+@pytest.mark.asyncio
+async def test_schedule_entry_startup_completion_runs_inline_without_loop(monkeypatch):
+    hass = DummyHass()
+    entry = DummyEntry()
+    calls = []
+
+    async def fake_complete(*_args, **_kwargs):
+        calls.append("done")
+
+    monkeypatch.setattr(init_module, "_complete_entry_startup", fake_complete)
+
+    await init_module._schedule_entry_startup_completion(
+        hass,
+        entry,
+        coordinator=object(),
+        session_manager=object(),
+        service_shield=None,
+        telemetry_store=None,
+        battery_prediction_enabled=False,
+    )
+
+    assert calls == ["done"]
+
+
+@pytest.mark.asyncio
+async def test_schedule_entry_startup_completion_uses_background_task(monkeypatch):
+    hass = TrackingHass()
+    hass.loop = object()
+    entry = DummyEntry()
+    calls = []
+
+    async def fake_complete(*_args, **_kwargs):
+        calls.append("done")
+
+    monkeypatch.setattr(init_module, "_complete_entry_startup", fake_complete)
+
+    await init_module._schedule_entry_startup_completion(
+        hass,
+        entry,
+        coordinator=object(),
+        session_manager=object(),
+        service_shield=None,
+        telemetry_store=None,
+        battery_prediction_enabled=True,
+    )
+
+    assert calls == []
+    assert len(hass.created_tasks) == 1
+
+    await hass.created_tasks[0]
+
+    assert calls == ["done"]
 
 
 @pytest.mark.asyncio
@@ -495,6 +727,95 @@ async def test_init_session_manager_uses_first_refresh_during_setup(monkeypatch)
         extended_scan_interval=300,
     )
 
+    assert coordinator.first_refresh_called is True
+    assert coordinator.refresh_called is False
+
+
+@pytest.mark.asyncio
+async def test_init_session_manager_defers_refresh_during_setup_when_cache_available(
+    monkeypatch,
+):
+    monkeypatch.setattr(init_module, "OigCloudApi", DummyApi)
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.api.oig_cloud_session_manager.OigCloudSessionManager",
+        DummySessionManager,
+    )
+    monkeypatch.setattr(
+        init_module, "OigCloudCoordinator", DummyCoordinatorWithRefresh
+    )
+    monkeypatch.setattr(DummyCoordinatorWithRefresh, "startup_cache_loaded", True)
+    monkeypatch.setattr(
+        init_module,
+        "get_data_source_state",
+        lambda *_a, **_k: SimpleNamespace(
+            effective_mode="local_only",
+            configured_mode="local_only",
+            local_available=True,
+        ),
+    )
+
+    hass = DummyHass()
+    hass.loop = asyncio.get_running_loop()
+    entry = DummyEntry(data={CONF_USERNAME: "user", CONF_PASSWORD: "pass"})
+    entry.state = ConfigEntryState.SETUP_IN_PROGRESS
+
+    coordinator, _session_manager = await init_module._init_session_manager_and_coordinator(
+        hass=hass,
+        entry=entry,
+        username="user",
+        password="pass",
+        no_telemetry=True,
+        standard_scan_interval=30,
+        extended_scan_interval=300,
+    )
+
+    assert coordinator.hydrate_called is True
+    assert coordinator.first_refresh_called is False
+    assert coordinator.refresh_called is False
+
+
+@pytest.mark.asyncio
+async def test_init_session_manager_uses_first_refresh_when_only_box_id_exists(
+    monkeypatch,
+):
+    monkeypatch.setattr(init_module, "OigCloudApi", DummyApi)
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.api.oig_cloud_session_manager.OigCloudSessionManager",
+        DummySessionManager,
+    )
+    monkeypatch.setattr(
+        init_module, "OigCloudCoordinator", DummyCoordinatorWithRefresh
+    )
+    monkeypatch.setattr(DummyCoordinatorWithRefresh, "startup_cache_loaded", False)
+    monkeypatch.setattr(
+        init_module,
+        "get_data_source_state",
+        lambda *_a, **_k: SimpleNamespace(
+            effective_mode=init_module.DATA_SOURCE_CLOUD_ONLY,
+            configured_mode=init_module.DATA_SOURCE_CLOUD_ONLY,
+            local_available=False,
+        ),
+    )
+
+    hass = DummyHass()
+    hass.loop = asyncio.get_running_loop()
+    entry = DummyEntry(
+        data={CONF_USERNAME: "user", CONF_PASSWORD: "pass"},
+        options={"box_id": "2206237016"},
+    )
+    entry.state = ConfigEntryState.SETUP_IN_PROGRESS
+
+    coordinator, _session_manager = await init_module._init_session_manager_and_coordinator(
+        hass=hass,
+        entry=entry,
+        username="user",
+        password="pass",
+        no_telemetry=True,
+        standard_scan_interval=30,
+        extended_scan_interval=300,
+    )
+
+    assert coordinator.hydrate_called is True
     assert coordinator.first_refresh_called is True
     assert coordinator.refresh_called is False
 
@@ -1396,7 +1717,7 @@ async def test_async_setup_entry_optional_modules(monkeypatch):
         lambda _coord: "123",
     )
 
-    callbacks = {"interval": None}
+    callbacks: dict[str, AsyncEventCallback | None] = {"interval": None}
 
     def fake_track_interval(_hass, callback, _delta):
         callbacks["interval"] = callback
@@ -1460,8 +1781,8 @@ async def test_async_setup_entry_optional_modules(monkeypatch):
     result = await init_module.async_setup_entry(hass, entry)
 
     assert result is True
-    assert callbacks["interval"] is not None
-    await callbacks["interval"](None)
+    interval_cb = cast(AsyncEventCallback, callbacks["interval"])
+    await interval_cb(None)
 
 
 @pytest.mark.asyncio
@@ -2138,10 +2459,11 @@ async def test_async_setup_entry_persist_box_id_error(monkeypatch):
     )
     hass.data[DOMAIN] = {entry.entry_id: {}}
 
-    def raising_update(_entry, options=None):
+    def raising_update(entry, options=None, data=None):
+        del data
         if options and "box_id" in options:
             raise RuntimeError("boom")
-        _entry.options = options or {}
+        entry.options = options or {}
 
     hass.config_entries.async_update_entry = raising_update
 
@@ -2263,7 +2585,10 @@ async def test_async_setup_entry_balancing_manager_paths(monkeypatch):
     )
     monkeypatch.setattr(init_module, "BalancingManager", DummyBalancingManager)
 
-    callbacks = {"interval": None, "later": None}
+    callbacks: dict[str, Callable[[Any], Awaitable[None]] | None] = {
+        "interval": None,
+        "later": None,
+    }
 
     def fake_track_interval(_hass, callback, _delta):
         callbacks["interval"] = callback
@@ -2313,7 +2638,9 @@ async def test_async_setup_entry_balancing_manager_paths(monkeypatch):
     result = await init_module.async_setup_entry(hass, entry)
 
     assert result is True
-    await callbacks["interval"](None)
+    interval_cb = callbacks["interval"]
+    assert interval_cb is not None
+    await interval_cb(None)
 
 
 @pytest.mark.asyncio
@@ -2445,7 +2772,10 @@ async def test_async_setup_entry_balancing_manager_executes(monkeypatch):
     )
     monkeypatch.setattr(init_module, "BalancingManager", DummyBalancingManager)
 
-    callbacks = {"interval": None, "later": None}
+    callbacks: dict[str, AsyncEventCallback | None] = {
+        "interval": None,
+        "later": None,
+    }
 
     def fake_track_interval(_hass, callback, _delta):
         callbacks["interval"] = callback
@@ -2496,8 +2826,10 @@ async def test_async_setup_entry_balancing_manager_executes(monkeypatch):
     result = await init_module.async_setup_entry(hass, entry)
 
     assert result is True
-    await callbacks["interval"](None)
-    await callbacks["later"](None)
+    interval_cb = cast(AsyncEventCallback, callbacks["interval"])
+    later_cb = cast(AsyncEventCallback, callbacks["later"])
+    await interval_cb(None)
+    await later_cb(None)
 
 
 @pytest.mark.asyncio
@@ -2912,7 +3244,7 @@ async def test_async_setup_entry_shield_monitoring_no_telemetry(monkeypatch):
         ),
     )
 
-    callbacks = {"interval": None}
+    callbacks: dict[str, Callable[[Any], Awaitable[None]] | None] = {"interval": None}
 
     def fake_track_interval(_hass, callback, _delta):
         callbacks["interval"] = callback
@@ -2954,4 +3286,6 @@ async def test_async_setup_entry_shield_monitoring_no_telemetry(monkeypatch):
     result = await init_module.async_setup_entry(hass, entry)
 
     assert result is True
-    await callbacks["interval"](None)
+    interval_cb = callbacks["interval"]
+    assert interval_cb is not None
+    await interval_cb(None)

--- a/tests/test_ote_api.py
+++ b/tests/test_ote_api.py
@@ -428,7 +428,7 @@ async def test_cnb_rate_get_day_rates_failure(monkeypatch):
 @pytest.mark.asyncio
 async def test_cnb_rate_get_current_rates_cache(monkeypatch):
     rate = CnbRate()
-    today = datetime.now(timezone.utc).date()
+    today = datetime.now(rate._timezone).date()
     rate._rates = {"EUR": Decimal("25")}
     rate._last_checked_date = today
     rates = await rate.get_current_rates()
@@ -438,7 +438,7 @@ async def test_cnb_rate_get_current_rates_cache(monkeypatch):
 @pytest.mark.asyncio
 async def test_cnb_rate_get_current_rates_updates(monkeypatch):
     rate = CnbRate()
-    today = datetime.now(timezone.utc).date()
+    today = datetime.now(rate._timezone).date()
 
     async def fake_day_rates(_day):
         return {"EUR": Decimal("26")}

--- a/tests/test_sensor_setup_entry.py
+++ b/tests/test_sensor_setup_entry.py
@@ -4,8 +4,6 @@ from types import SimpleNamespace
 
 import pytest
 
-pytest.importorskip("numpy")
-
 from custom_components.oig_cloud.const import DOMAIN
 from custom_components.oig_cloud import sensor as sensor_module
 
@@ -252,6 +250,7 @@ async def test_schedule_deferred_sensor_registration_runs_inline_without_loop():
 
     sensor_module._schedule_deferred_sensor_registration(
         hass,
+        "entry1",
         _add_entities,
         [lambda: [DummySensor()], lambda: [DummySensor()]],
     )
@@ -280,6 +279,7 @@ async def test_schedule_deferred_sensor_registration_uses_background_task():
 
     sensor_module._schedule_deferred_sensor_registration(
         hass,
+        "entry1",
         _add_entities,
         [lambda: [DummySensor()]],
     )
@@ -288,6 +288,46 @@ async def test_schedule_deferred_sensor_registration_uses_background_task():
     assert len(hass.tasks) == 1
 
     await hass.tasks[0]
+
+    assert len(added) == 1
+    assert added[0]._attr_has_entity_name is False
+
+
+@pytest.mark.asyncio
+async def test_schedule_deferred_sensor_registration_skips_unloaded_entry():
+    hass = DummyHass("entry1")
+    added = []
+
+    def _add_entities(entities, _update=False):
+        added.extend(entities)
+
+    sensor_module._schedule_deferred_sensor_registration(
+        hass,
+        "missing-entry",
+        _add_entities,
+        [lambda: [DummySensor()]],
+    )
+
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_schedule_deferred_sensor_registration_continues_after_factory_error():
+    hass = DummyHass("entry1")
+    added = []
+
+    def _add_entities(entities, _update=False):
+        added.extend(entities)
+
+    def _boom():
+        raise RuntimeError("factory failed")
+
+    sensor_module._schedule_deferred_sensor_registration(
+        hass,
+        "entry1",
+        _add_entities,
+        [_boom, lambda: [DummySensor()]],
+    )
 
     assert len(added) == 1
     assert added[0]._attr_has_entity_name is False

--- a/tests/test_sensor_setup_entry.py
+++ b/tests/test_sensor_setup_entry.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 
 import pytest
 
+pytest.importorskip("numpy")
+
 from custom_components.oig_cloud.const import DOMAIN
 from custom_components.oig_cloud import sensor as sensor_module
 
@@ -30,6 +32,9 @@ class DummyHass:
     def __init__(self, entry_id):
         self.data = {DOMAIN: {entry_id: {"coordinator": DummyCoordinator(), "statistics_enabled": True}}}
         self.config_entries = DummyConfigEntries()
+
+    def async_create_task(self, coro):
+        return coro
 
 
 class DummyEntry:
@@ -235,3 +240,54 @@ async def test_sensor_async_setup_entry_no_box_id(monkeypatch):
     await sensor_module.async_setup_entry(hass, entry, _add_entities)
 
     assert not added
+
+
+@pytest.mark.asyncio
+async def test_schedule_deferred_sensor_registration_runs_inline_without_loop():
+    hass = DummyHass("entry1")
+    added = []
+
+    def _add_entities(entities, _update=False):
+        added.extend(entities)
+
+    sensor_module._schedule_deferred_sensor_registration(
+        hass,
+        _add_entities,
+        [lambda: [DummySensor()], lambda: [DummySensor()]],
+    )
+
+    assert len(added) == 2
+    assert all(getattr(entity, "_attr_has_entity_name", None) is False for entity in added)
+
+
+@pytest.mark.asyncio
+async def test_schedule_deferred_sensor_registration_uses_background_task():
+    class LoopHass(DummyHass):
+        def __init__(self, entry_id):
+            super().__init__(entry_id)
+            self.loop = object()
+            self.tasks = []
+
+        def async_create_task(self, coro):
+            self.tasks.append(coro)
+            return coro
+
+    hass = LoopHass("entry1")
+    added = []
+
+    def _add_entities(entities, _update=False):
+        added.extend(entities)
+
+    sensor_module._schedule_deferred_sensor_registration(
+        hass,
+        _add_entities,
+        [lambda: [DummySensor()]],
+    )
+
+    assert added == []
+    assert len(hass.tasks) == 1
+
+    await hass.tasks[0]
+
+    assert len(added) == 1
+    assert added[0]._attr_has_entity_name is False


### PR DESCRIPTION
## Summary
- throttle and coalesce local telemetry snapshot publishes so local event bursts no longer flood the coordinator websocket path
- hydrate cached coordinator data first and defer non-critical startup work while keeping boiler coordinator sequencing safe during setup
- defer optional sensor registration, bump the integration to 2.3.12, and document the release fixes in the changelog

## Verification
- `.venv/bin/pytest tests/test_data_source_controller.py tests/test_init_setup_entry.py tests/test_sensor_setup_entry.py`
- `.venv/bin/python -m compileall custom_components/oig_cloud tests`
