### PR TITLE
fix: ship 2.3.13 install and startup hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.13] - 2026-04-04
+
+### Fixed
+- Dashboard panel registration no longer blocks config entry bootstrap, preventing setup cancellation during Home Assistant startup on fresh installs.
+- Battery balancing startup now treats missing forecast sensor wiring as a transient deferred-registration race, avoiding false warning logs during initial setup.
+- Recorder history queries for battery forecast interval data now run through the recorder executor, eliminating repeated Home Assistant database access warnings.
+- Options-flow wizard progress logging was reduced from warning-level noise to normal debug/info output.
+
 ## [2.3.12] - 2026-04-03
 
 ### Fixed

--- a/custom_components/oig_cloud/__init__.py
+++ b/custom_components/oig_cloud/__init__.py
@@ -1434,6 +1434,10 @@ async def _complete_entry_startup(
     battery_prediction_enabled: bool,
 ) -> None:
     try:
+        dashboard_enabled = bool(
+            hass.data.get(DOMAIN, {}).get(entry.entry_id, {}).get("dashboard_enabled", False)
+        )
+
         state = get_data_source_state(hass, entry.entry_id)
         should_check_cloud_now = state.effective_mode == DATA_SOURCE_CLOUD_ONLY
 
@@ -1477,7 +1481,14 @@ async def _complete_entry_startup(
                 "data_source_controller"
             ] = data_source_controller
 
+        await _sync_dashboard_panel(hass, entry, dashboard_enabled)
+
         _LOGGER.info("Background startup completion finished for entry %s", entry.entry_id)
+    except asyncio.CancelledError:
+        _LOGGER.debug(
+            "Background startup completion cancelled for entry %s", entry.entry_id
+        )
+        raise
     except Exception as err:
         _LOGGER.warning(
             "Background startup completion failed for entry %s: %s",
@@ -1627,8 +1638,6 @@ async def async_setup_entry(
         # that can be left behind after unique_id/device_id stabilization.
         await _schedule_invalid_device_cleanup(hass, entry)
         await _migrate_entity_names_to_legacy_short_names(hass, entry)
-
-        await _sync_dashboard_panel(hass, entry, dashboard_enabled)
 
         # Přidáme listener pro změny konfigurace - OPRAVEN callback na async funkci
         entry.async_on_unload(entry.add_update_listener(async_update_options))

--- a/custom_components/oig_cloud/battery_forecast/balancing/core.py
+++ b/custom_components/oig_cloud/battery_forecast/balancing/core.py
@@ -286,7 +286,10 @@ class BalancingManager:
         _LOGGER.debug(f"BalancingManager: check_balancing() CALLED (force={force})")
 
         if not self._forecast_sensor:
-            _LOGGER.warning("Forecast sensor not set, cannot check balancing")
+            _LOGGER.debug(
+                "Forecast sensor not set yet for box %s, skipping balancing check",
+                self.box_id,
+            )
             return None
 
         if await self._handle_recent_balancing():

--- a/custom_components/oig_cloud/battery_forecast/data/history.py
+++ b/custom_components/oig_cloud/battery_forecast/data/history.py
@@ -281,11 +281,13 @@ async def fetch_interval_from_history(  # noqa: C901
 
     try:
         from homeassistant.components.recorder.history import get_significant_states
+        from homeassistant.helpers.recorder import get_instance
 
         box_id = sensor._box_id  # pylint: disable=protected-access
         entity_ids = _build_history_entity_ids(box_id)
 
-        states = await sensor._hass.async_add_executor_job(  # pylint: disable=protected-access
+        recorder_instance = get_instance(sensor._hass)  # pylint: disable=protected-access
+        states = await recorder_instance.async_add_executor_job(
             get_significant_states,
             sensor._hass,
             start_time,
@@ -469,8 +471,10 @@ async def fetch_mode_history_from_recorder(
 
     try:
         from homeassistant.components.recorder import history
+        from homeassistant.helpers.recorder import get_instance
 
-        history_data = await sensor._hass.async_add_executor_job(  # pylint: disable=protected-access
+        recorder_instance = get_instance(sensor._hass)  # pylint: disable=protected-access
+        history_data = await recorder_instance.async_add_executor_job(
             history.state_changes_during_period,
             sensor._hass,
             start_time,

--- a/custom_components/oig_cloud/config/steps.py
+++ b/custom_components/oig_cloud/config/steps.py
@@ -2767,7 +2767,7 @@ class OigCloudOptionsFlowHandler(WizardMixin, config_entries.OptionsFlow):
             new_options = self._build_options_payload(self._wizard_data)
 
             # Přidat debug log
-            _LOGGER.warning(
+            _LOGGER.debug(
                 f"🔧 OptionsFlow wizard_summary: Updating config entry with {len(new_options)} options"
             )
             _LOGGER.debug(
@@ -2776,20 +2776,20 @@ class OigCloudOptionsFlowHandler(WizardMixin, config_entries.OptionsFlow):
 
             try:
                 # Aktualizovat entry
-                _LOGGER.warning("🔍 About to call async_update_entry")
+                _LOGGER.debug("🔍 About to call async_update_entry")
                 self.hass.config_entries.async_update_entry(
                     self.config_entry, options=new_options
                 )
-                _LOGGER.warning("🔍 async_update_entry completed")
+                _LOGGER.debug("🔍 async_update_entry completed")
 
                 # Automaticky reloadnout integraci pro aplikování změn
-                _LOGGER.warning("🔍 About to reload integration")
+                _LOGGER.debug("🔍 About to reload integration")
                 await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-                _LOGGER.warning("🔍 Integration reload completed")
+                _LOGGER.debug("🔍 Integration reload completed")
 
                 # CRITICAL: V OptionsFlow NESMÍME volat async_create_entry,
                 # protože by to přepsalo options! Místo toho ukončit flow.
-                _LOGGER.warning(
+                _LOGGER.info(
                     "🔍 OptionsFlow wizard completed - showing success message"
                 )
                 return self.async_abort(reason="reconfigure_successful")

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.12",
+  "version": "2.3.13",
   "zeroconf": []
 }

--- a/tests/test_balancing_manager_core.py
+++ b/tests/test_balancing_manager_core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+import logging
 
 import pytest
 
@@ -59,6 +60,18 @@ async def test_check_balancing_requires_forecast_sensor(monkeypatch):
 
     result = await manager.check_balancing()
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_check_balancing_without_forecast_sensor_logs_debug(monkeypatch, caplog):
+    monkeypatch.setattr(core_module, "Store", DummyStore)
+    manager = core_module.BalancingManager(SimpleNamespace(), "123", "path", DummyEntry())
+
+    with caplog.at_level(logging.DEBUG):
+        result = await manager.check_balancing()
+
+    assert result is None
+    assert "Forecast sensor not set yet for box 123" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_history_helpers.py
+++ b/tests/test_history_helpers.py
@@ -1,6 +1,7 @@
 import builtins
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -24,11 +25,15 @@ class DummySensor:
     def __init__(self, hass):
         self._hass = hass
         self._box_id = "123"
+        self._daily_plan_state: dict[str, Any] | None = None
 
     def _get_total_battery_capacity(self):
         return 10.0
 
     def _log_rate_limited(self, *args, **kwargs):
+        return None
+
+    async def _load_plan_from_storage(self, *_args, **_kwargs) -> dict[str, Any] | None:
         return None
 
 
@@ -37,6 +42,15 @@ class DummyHass:
         self.data = {}
 
     async def async_add_executor_job(self, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+
+class DummyRecorderInstance:
+    def __init__(self):
+        self.calls = []
+
+    async def async_add_executor_job(self, func, *args, **kwargs):
+        self.calls.append((func, args, kwargs))
         return func(*args, **kwargs)
 
 
@@ -118,7 +132,7 @@ def test_build_actual_interval_entry_rounding():
 
 
 @pytest.mark.asyncio
-async def test_fetch_interval_from_history_basic(hass, monkeypatch):
+async def test_fetch_interval_from_history_basic(monkeypatch):
     start = datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc)
     end = start + timedelta(minutes=15)
 
@@ -139,12 +153,15 @@ async def test_fetch_interval_from_history_basic(hass, monkeypatch):
     def fake_get_significant_states(*_args, **_kwargs):
         return states
 
+    recorder_instance = DummyRecorderInstance()
+
     monkeypatch.setattr(
         "homeassistant.components.recorder.history.get_significant_states",
         fake_get_significant_states,
     )
+    monkeypatch.setattr("homeassistant.helpers.recorder.get_instance", lambda _hass: recorder_instance)
 
-    sensor = DummySensor(hass)
+    sensor = DummySensor(DummyHass())
     result = await history_module.fetch_interval_from_history(sensor, start, end)
 
     assert result is not None
@@ -159,6 +176,7 @@ async def test_fetch_interval_from_history_basic(hass, monkeypatch):
     assert result["net_cost"] == 1.3
     assert result["mode"] == CBB_MODE_HOME_UPS
     assert result["mode_name"] == CBB_MODE_NAMES[CBB_MODE_HOME_UPS]
+    assert len(recorder_instance.calls) == 1
 
 
 @pytest.mark.asyncio
@@ -175,7 +193,7 @@ async def test_fetch_interval_from_history_no_hass():
 
 
 @pytest.mark.asyncio
-async def test_fetch_interval_from_history_no_states(hass, monkeypatch):
+async def test_fetch_interval_from_history_no_states(monkeypatch):
     def fake_get_significant_states(*_args, **_kwargs):
         return {}
 
@@ -183,7 +201,8 @@ async def test_fetch_interval_from_history_no_states(hass, monkeypatch):
         "homeassistant.components.recorder.history.get_significant_states",
         fake_get_significant_states,
     )
-    sensor = DummySensor(hass)
+    monkeypatch.setattr("homeassistant.helpers.recorder.get_instance", lambda _hass: DummyRecorderInstance())
+    sensor = DummySensor(DummyHass())
     result = await history_module.fetch_interval_from_history(
         sensor,
         datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc),
@@ -193,7 +212,7 @@ async def test_fetch_interval_from_history_no_states(hass, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fetch_interval_from_history_exception(hass, monkeypatch):
+async def test_fetch_interval_from_history_exception(monkeypatch):
     def fake_get_significant_states(*_args, **_kwargs):
         raise RuntimeError("boom")
 
@@ -201,13 +220,40 @@ async def test_fetch_interval_from_history_exception(hass, monkeypatch):
         "homeassistant.components.recorder.history.get_significant_states",
         fake_get_significant_states,
     )
-    sensor = DummySensor(hass)
+    monkeypatch.setattr("homeassistant.helpers.recorder.get_instance", lambda _hass: DummyRecorderInstance())
+    sensor = DummySensor(DummyHass())
     result = await history_module.fetch_interval_from_history(
         sensor,
         datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc),
         datetime(2025, 1, 1, 0, 15, tzinfo=timezone.utc),
     )
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_mode_history_uses_recorder_executor(monkeypatch):
+    start = datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=15)
+    sensor_id = "sensor.oig_123_box_prms_mode"
+    recorder_instance = DummyRecorderInstance()
+
+    def fake_state_changes(*_args, **_kwargs):
+        return {
+            sensor_id: [DummyState(SERVICE_MODE_HOME_UPS, end)],
+        }
+
+    monkeypatch.setattr(
+        "homeassistant.components.recorder.history.state_changes_during_period",
+        fake_state_changes,
+    )
+    monkeypatch.setattr("homeassistant.helpers.recorder.get_instance", lambda _hass: recorder_instance)
+
+    sensor = DummySensor(DummyHass())
+    result = await history_module.fetch_mode_history_from_recorder(sensor, start, end)
+
+    assert len(result) == 1
+    assert result[0]["mode"] == CBB_MODE_HOME_UPS
+    assert len(recorder_instance.calls) == 1
 
 
 @pytest.mark.asyncio
@@ -294,15 +340,18 @@ async def test_fetch_mode_history_from_recorder_no_hass():
 
 
 @pytest.mark.asyncio
-async def test_fetch_mode_history_from_recorder_empty(hass, monkeypatch):
+async def test_fetch_mode_history_from_recorder_empty(monkeypatch):
     def fake_state_changes(*_args, **_kwargs):
         return {}
+
+    recorder_instance = DummyRecorderInstance()
 
     monkeypatch.setattr(
         "homeassistant.components.recorder.history.state_changes_during_period",
         fake_state_changes,
     )
-    sensor = DummySensor(hass)
+    monkeypatch.setattr("homeassistant.helpers.recorder.get_instance", lambda _hass: recorder_instance)
+    sensor = DummySensor(DummyHass())
     result = await history_module.fetch_mode_history_from_recorder(
         sensor,
         datetime(2025, 1, 1, 0, 0),
@@ -332,8 +381,9 @@ async def test_fetch_mode_history_from_recorder_import_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fetch_mode_history_from_recorder_empty_states(hass, monkeypatch):
+async def test_fetch_mode_history_from_recorder_empty_states(monkeypatch):
     sensor_id = "sensor.oig_123_box_prms_mode"
+    recorder_instance = DummyRecorderInstance()
 
     def fake_state_changes(*_args, **_kwargs):
         return {sensor_id: []}
@@ -342,7 +392,8 @@ async def test_fetch_mode_history_from_recorder_empty_states(hass, monkeypatch):
         "homeassistant.components.recorder.history.state_changes_during_period",
         fake_state_changes,
     )
-    sensor = DummySensor(hass)
+    monkeypatch.setattr("homeassistant.helpers.recorder.get_instance", lambda _hass: recorder_instance)
+    sensor = DummySensor(DummyHass())
     result = await history_module.fetch_mode_history_from_recorder(
         sensor,
         datetime(2025, 1, 1, 0, 0),
@@ -352,7 +403,9 @@ async def test_fetch_mode_history_from_recorder_empty_states(hass, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fetch_mode_history_from_recorder_exception(hass, monkeypatch):
+async def test_fetch_mode_history_from_recorder_exception(monkeypatch):
+    recorder_instance = DummyRecorderInstance()
+
     def fake_state_changes(*_args, **_kwargs):
         raise RuntimeError("boom")
 
@@ -360,7 +413,8 @@ async def test_fetch_mode_history_from_recorder_exception(hass, monkeypatch):
         "homeassistant.components.recorder.history.state_changes_during_period",
         fake_state_changes,
     )
-    sensor = DummySensor(hass)
+    monkeypatch.setattr("homeassistant.helpers.recorder.get_instance", lambda _hass: recorder_instance)
+    sensor = DummySensor(DummyHass())
     result = await history_module.fetch_mode_history_from_recorder(
         sensor,
         datetime(2025, 1, 1, 0, 0),
@@ -370,8 +424,9 @@ async def test_fetch_mode_history_from_recorder_exception(hass, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fetch_mode_history_from_recorder_filters_states(hass, monkeypatch):
+async def test_fetch_mode_history_from_recorder_filters_states(monkeypatch):
     sensor_id = "sensor.oig_123_box_prms_mode"
+    recorder_instance = DummyRecorderInstance()
     states = [
         SimpleNamespace(state="unavailable", last_changed=datetime(2025, 1, 1, 0, 0)),
         SimpleNamespace(state="Home 1", last_changed=datetime(2025, 1, 1, 0, 15)),
@@ -384,7 +439,8 @@ async def test_fetch_mode_history_from_recorder_filters_states(hass, monkeypatch
         "homeassistant.components.recorder.history.state_changes_during_period",
         fake_state_changes,
     )
-    sensor = DummySensor(hass)
+    monkeypatch.setattr("homeassistant.helpers.recorder.get_instance", lambda _hass: recorder_instance)
+    sensor = DummySensor(DummyHass())
     result = await history_module.fetch_mode_history_from_recorder(
         sensor,
         datetime(2025, 1, 1, 0, 0),

--- a/tests/test_init_setup_entry.py
+++ b/tests/test_init_setup_entry.py
@@ -260,6 +260,9 @@ async def test_complete_entry_startup_cloud_initializes_deferred_components(
     async def fake_start_data_source_controller(*_args, **_kwargs):
         return controller
 
+    async def fake_sync_dashboard_panel(_hass, _entry, enabled):
+        assert enabled is True
+
     monkeypatch.setattr(
         init_module,
         "get_data_source_state",
@@ -283,6 +286,7 @@ async def test_complete_entry_startup_cloud_initializes_deferred_components(
         "_start_data_source_controller",
         fake_start_data_source_controller,
     )
+    monkeypatch.setattr(init_module, "_sync_dashboard_panel", fake_sync_dashboard_panel)
 
     await init_module._complete_entry_startup(
         hass,
@@ -323,6 +327,9 @@ async def test_complete_entry_startup_local_skips_cloud_refresh(monkeypatch):
     async def fake_start_data_source_controller(*_args, **_kwargs):
         return None
 
+    async def fake_sync_dashboard_panel(_hass, _entry, enabled):
+        assert enabled is False
+
     async def fail_live_data_check(_api):
         raise AssertionError("live-data check should be skipped in local mode")
 
@@ -347,6 +354,7 @@ async def test_complete_entry_startup_local_skips_cloud_refresh(monkeypatch):
         "_start_data_source_controller",
         fake_start_data_source_controller,
     )
+    monkeypatch.setattr(init_module, "_sync_dashboard_panel", fake_sync_dashboard_panel)
 
     await init_module._complete_entry_startup(
         hass,
@@ -361,6 +369,60 @@ async def test_complete_entry_startup_local_skips_cloud_refresh(monkeypatch):
     assert session_manager.ensure_called is False
     assert coordinator.refresh_called is False
     assert coordinator.first_refresh_called is False
+
+
+@pytest.mark.asyncio
+async def test_complete_entry_startup_handles_dashboard_sync_failure(monkeypatch):
+    hass = DummyHass()
+    entry = DummyEntry()
+    coordinator = TrackingCoordinator()
+    session_manager = DummySessionManager(DummyApi())
+
+    hass.data[DOMAIN] = {entry.entry_id: {"dashboard_enabled": True}}
+
+    async def fake_init_notification_manager(*_args, **_kwargs):
+        return None
+
+    async def fake_init_balancing_manager(*_args, **_kwargs):
+        return None
+
+    async def fake_start_data_source_controller(*_args, **_kwargs):
+        return None
+
+    async def fake_sync_dashboard_panel(*_args, **_kwargs):
+        raise RuntimeError("dashboard boom")
+
+    monkeypatch.setattr(
+        init_module,
+        "get_data_source_state",
+        lambda *_a, **_k: SimpleNamespace(effective_mode="local_only"),
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_init_notification_manager",
+        fake_init_notification_manager,
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_init_balancing_manager",
+        fake_init_balancing_manager,
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_start_data_source_controller",
+        fake_start_data_source_controller,
+    )
+    monkeypatch.setattr(init_module, "_sync_dashboard_panel", fake_sync_dashboard_panel)
+
+    await init_module._complete_entry_startup(
+        hass,
+        entry,
+        coordinator,
+        session_manager,
+        service_shield=None,
+        telemetry_store=None,
+        battery_prediction_enabled=False,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move dashboard panel registration out of the blocking config-entry setup path so fresh installs no longer fail on bootstrap timeout
- route recorder history lookups through the recorder executor and lower harmless startup warning noise for balancing and options flow progress
- bump the integration to 2.3.13 and document the install/runtime hotfixes in the changelog

## Verification
- `.venv/bin/pytest tests/test_init_setup_entry.py tests/test_balancing_manager_core.py tests/test_history_helpers.py tests/test_config_options_flow.py tests/test_config_steps_wizard_extra.py`
- `.venv/bin/python -m flake8 custom_components/oig_cloud tests --max-line-length=120`
- `.venv/bin/python -m compileall custom_components/oig_cloud tests`
