### PR TITLE
fix: ship 2.3.14 runtime cleanup hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.14] - 2026-04-04
+
+### Fixed
+- Boiler coordinator refresh now runs in deferred startup without blocking config-entry setup, while boiler refresh failures no longer abort the rest of background startup completion.
+- Boiler energy-needed sensor metadata no longer triggers Home Assistant energy state-class warnings during runtime.
+- Auto-switch watchdog corrections are now rate-limited, reducing repeated warning spam when the watchdog keeps the box aligned with the planned mode.
+- Expected telemetry delivery failures (HTTP 400/401/403) are now rate-limited and downgraded from warning spam while preserving diagnostics for unexpected failures.
+
 ## [2.3.13] - 2026-04-04
 
 ### Fixed

--- a/custom_components/oig_cloud/__init__.py
+++ b/custom_components/oig_cloud/__init__.py
@@ -1305,9 +1305,7 @@ async def _init_boiler_coordinator(
             boiler_config["box_id"] = box_id
         coordinator = BoilerCoordinator(hass, boiler_config)
 
-        await coordinator.async_config_entry_first_refresh()
-
-        _LOGGER.info("Boiler coordinator successfully initialized")
+        _LOGGER.info("Boiler coordinator created; deferring initial refresh")
         return coordinator
     except Exception as err:
         _LOGGER.error("Failed to initialize Boiler coordinator: %s", err)
@@ -1437,6 +1435,21 @@ async def _complete_entry_startup(
         dashboard_enabled = bool(
             hass.data.get(DOMAIN, {}).get(entry.entry_id, {}).get("dashboard_enabled", False)
         )
+        boiler_coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id, {}).get(
+            "boiler_coordinator"
+        )
+
+        if boiler_coordinator is not None:
+            try:
+                await boiler_coordinator.async_config_entry_first_refresh()
+                _LOGGER.info("Boiler coordinator successfully initialized")
+            except Exception as err:
+                _LOGGER.warning(
+                    "Boiler coordinator deferred refresh failed for entry %s: %s",
+                    entry.entry_id,
+                    err,
+                    exc_info=True,
+                )
 
         state = get_data_source_state(hass, entry.entry_id)
         should_check_cloud_now = state.effective_mode == DATA_SOURCE_CLOUD_ONLY

--- a/custom_components/oig_cloud/battery_forecast/planning/auto_switch.py
+++ b/custom_components/oig_cloud/battery_forecast/planning/auto_switch.py
@@ -31,6 +31,7 @@ from .precedence_contract import PrecedenceLevel
 
 _LOGGER = logging.getLogger(__name__)
 MIN_AUTO_SWITCH_INTERVAL_MINUTES = 30
+WATCHDOG_WARNING_COOLDOWN_SECONDS = 300.0
 
 
 # Reason code constants for switch decisions
@@ -232,6 +233,28 @@ def stop_auto_switch_watchdog(sensor: Any) -> None:
         _LOGGER.debug("[AutoModeSwitch] Watchdog stopped")
 
 
+def _log_watchdog_correction(sensor: Any, current_mode: Optional[str], desired_mode: str, context: SwitchContext) -> None:
+    log_rl = getattr(sensor, "_log_rate_limited", None)
+    if log_rl:
+        log_rl(
+            "auto_mode_switch_watchdog_correction",
+            "warning",
+            "[AutoModeSwitch] Watchdog correcting mode from %s -> %s (%s)",
+            current_mode or "unknown",
+            desired_mode,
+            context.to_log_string(),
+            cooldown_s=WATCHDOG_WARNING_COOLDOWN_SECONDS,
+        )
+        return
+
+    _LOGGER.debug(
+        "[AutoModeSwitch] Watchdog correcting mode from %s -> %s (%s)",
+        current_mode or "unknown",
+        desired_mode,
+        context.to_log_string(),
+    )
+
+
 async def auto_switch_watchdog_tick(sensor: Any, now: datetime) -> None:
     """Periodic check that correct mode is applied."""
     if not auto_mode_switch_enabled(sensor):
@@ -260,12 +283,7 @@ async def auto_switch_watchdog_tick(sensor: Any, now: datetime) -> None:
             "desired_mode": desired_mode,
         },
     )
-    _LOGGER.warning(
-        "[AutoModeSwitch] Watchdog correcting mode from %s -> %s (%s)",
-        current_mode or "unknown",
-        desired_mode,
-        context.to_log_string(),
-    )
+    _log_watchdog_correction(sensor, current_mode, desired_mode, context)
     await ensure_current_mode(sensor, desired_mode, "watchdog enforcement", context=context)
 
 

--- a/custom_components/oig_cloud/boiler/sensors.py
+++ b/custom_components/oig_cloud/boiler/sensors.py
@@ -23,6 +23,11 @@ from .coordinator import BoilerCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
+def _coordinator_data(coordinator: BoilerCoordinator) -> dict[str, Any]:
+    data = getattr(coordinator, "data", None)
+    return data if isinstance(data, dict) else {}
+
+
 class BoilerSensorBase(CoordinatorEntity[BoilerCoordinator], SensorEntity):
     """Základní třída pro bojlerové senzory."""
 
@@ -124,7 +129,6 @@ class BoilerEnergyNeededSensor(BoilerSensorBase):
 
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:flash"
 
     def __init__(self, coordinator: BoilerCoordinator) -> None:
@@ -134,7 +138,7 @@ class BoilerEnergyNeededSensor(BoilerSensorBase):
     @property
     def native_value(self) -> Optional[float]:
         """Vrátí energii potřebnou k ohřevu."""
-        energy_state = self.coordinator.data.get("energy_state", {})
+        energy_state = _coordinator_data(self.coordinator).get("energy_state", {})
         return energy_state.get("energy_needed_kwh")
 
 
@@ -153,7 +157,7 @@ class BoilerTotalEnergySensor(BoilerSensorBase):
     @property
     def native_value(self) -> Optional[float]:
         """Vrátí celkovou energii."""
-        tracking = self.coordinator.data.get("energy_tracking", {})
+        tracking = _coordinator_data(self.coordinator).get("energy_tracking", {})
         return tracking.get("total_kwh")
 
 
@@ -172,7 +176,7 @@ class BoilerFVEEnergySensor(BoilerSensorBase):
     @property
     def native_value(self) -> Optional[float]:
         """Vrátí energii z FVE."""
-        tracking = self.coordinator.data.get("energy_tracking", {})
+        tracking = _coordinator_data(self.coordinator).get("energy_tracking", {})
         return tracking.get("fve_kwh")
 
 
@@ -191,7 +195,7 @@ class BoilerGridEnergySensor(BoilerSensorBase):
     @property
     def native_value(self) -> Optional[float]:
         """Vrátí energii ze sítě."""
-        tracking = self.coordinator.data.get("energy_tracking", {})
+        tracking = _coordinator_data(self.coordinator).get("energy_tracking", {})
         return tracking.get("grid_kwh")
 
 
@@ -210,7 +214,7 @@ class BoilerAltEnergySensor(BoilerSensorBase):
     @property
     def native_value(self) -> Optional[float]:
         """Vrátí alternativní energii."""
-        tracking = self.coordinator.data.get("energy_tracking", {})
+        tracking = _coordinator_data(self.coordinator).get("energy_tracking", {})
         return tracking.get("alt_kwh")
 
 
@@ -229,7 +233,7 @@ class BoilerCurrentSourceSensor(BoilerSensorBase):
     @property
     def native_value(self) -> Optional[str]:
         """Vrátí aktuální zdroj."""
-        tracking = self.coordinator.data.get("energy_tracking", {})
+        tracking = _coordinator_data(self.coordinator).get("energy_tracking", {})
         source = tracking.get("current_source", "grid")
 
         # Překlad do češtiny
@@ -253,7 +257,7 @@ class BoilerRecommendedSourceSensor(BoilerSensorBase):
     @property
     def native_value(self) -> Optional[str]:
         """Vrátí doporučený zdroj."""
-        recommended = self.coordinator.data.get("recommended_source")
+        recommended = _coordinator_data(self.coordinator).get("recommended_source")
         if not recommended:
             return None
 
@@ -278,13 +282,15 @@ class BoilerChargingRecommendedSensor(BoilerSensorBase):
     @property
     def native_value(self) -> str:
         """Vrátí ano/ne."""
-        recommended = self.coordinator.data.get("charging_recommended", False)
+        recommended = _coordinator_data(self.coordinator).get(
+            "charging_recommended", False
+        )
         return "ano" if recommended else "ne"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Atributy s detaily aktuálního slotu."""
-        current_slot = self.coordinator.data.get("current_slot")
+        current_slot = _coordinator_data(self.coordinator).get("current_slot")
         if not current_slot:
             return {}
 
@@ -313,7 +319,7 @@ class BoilerPlanEstimatedCostSensor(BoilerSensorBase):
     @property
     def native_value(self) -> Optional[float]:
         """Vrátí odhadovanou cenu."""
-        plan = self.coordinator.data.get("plan")
+        plan = _coordinator_data(self.coordinator).get("plan")
         if not plan:
             return None
         return round(plan.estimated_cost_czk, 2)
@@ -321,7 +327,7 @@ class BoilerPlanEstimatedCostSensor(BoilerSensorBase):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Atributy s rozpisem plánu."""
-        plan = self.coordinator.data.get("plan")
+        plan = _coordinator_data(self.coordinator).get("plan")
         if not plan:
             return {}
 

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.13",
+  "version": "2.3.14",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/shared/logging.py
+++ b/custom_components/oig_cloud/shared/logging.py
@@ -49,6 +49,15 @@ class SimpleTelemetry:
         self.headers = headers
         self.session: Optional[ClientSession] = None
         self._aiohttp_available = ClientSession is not None and TCPConnector is not None
+        self._last_failure_log: dict[str, float] = {}
+
+    def _should_log_failure(self, key: str, cooldown_s: float = 300.0) -> bool:
+        now = time.monotonic()
+        last = self._last_failure_log.get(key)
+        if last is not None and (now - last) < cooldown_s:
+            return False
+        self._last_failure_log[key] = now
+        return True
 
     async def _get_session(self) -> Optional[ClientSession]:
         """Získá nebo vytvoří aiohttp session."""
@@ -113,16 +122,26 @@ class SimpleTelemetry:
                     )
                     return True
                 else:
-                    _LOGGER.warning(
-                        f"[TELEMETRY] Failed to send {event_type}: HTTP {response.status} - {response_text[:100]}"
+                    log_message = (
+                        f"[TELEMETRY] Failed to send {event_type}: "
+                        f"HTTP {response.status} - {response_text[:100]}"
                     )
+                    failure_key = f"{event_type}:{response.status}"
+                    if response.status in {400, 401, 403}:
+                        if self._should_log_failure(failure_key):
+                            _LOGGER.info(log_message)
+                        else:
+                            _LOGGER.debug(log_message)
+                    else:
+                        _LOGGER.warning(log_message)
                     return False
 
         except Exception as e:
-            _LOGGER.error(
-                f"[TELEMETRY] Exception while sending {event_type} for {service_name}: {e}",
-                exc_info=True,
-            )
+            log_message = f"[TELEMETRY] Exception while sending {event_type} for {service_name}: {e}"
+            if self._should_log_failure(f"exception:{event_type}"):
+                _LOGGER.warning(log_message, exc_info=True)
+            else:
+                _LOGGER.debug(log_message, exc_info=True)
             return False
 
     async def close(self) -> None:

--- a/tests/test_balancing_manager_core.py
+++ b/tests/test_balancing_manager_core.py
@@ -7,6 +7,7 @@ import logging
 import pytest
 
 from custom_components.oig_cloud.battery_forecast.balancing import core as core_module
+from custom_components.oig_cloud.battery_forecast.planning import auto_switch as auto_switch_module
 from custom_components.oig_cloud.battery_forecast.balancing.plan import (
     BalancingMode,
     BalancingPlan,
@@ -31,6 +32,14 @@ class DummyStore:
 class DummyEntry:
     def __init__(self, options=None):
         self.options = options or {}
+
+
+class DummyRateLimitedSensor:
+    def __init__(self):
+        self.calls = []
+
+    def _log_rate_limited(self, key, level, message, *args, cooldown_s=None):
+        self.calls.append((key, level, message, args, cooldown_s))
 
 
 def _make_plan(start: datetime, end: datetime) -> BalancingPlan:
@@ -72,6 +81,27 @@ async def test_check_balancing_without_forecast_sensor_logs_debug(monkeypatch, c
 
     assert result is None
     assert "Forecast sensor not set yet for box 123" in caplog.text
+
+
+def test_log_watchdog_correction_uses_rate_limited_warning():
+    sensor = DummyRateLimitedSensor()
+    context = auto_switch_module.SwitchContext(
+        reason_code=auto_switch_module.REASON_WATCHDOG_ENFORCEMENT,
+        precedence_level=1,
+        precedence_name="AUTO_SWITCH",
+        decision_source="watchdog",
+    )
+
+    auto_switch_module._log_watchdog_correction(sensor, "Home UPS", "Home 1", context)
+
+    assert len(sensor.calls) == 1
+    key, level, message, args, cooldown_s = sensor.calls[0]
+    assert key == "auto_mode_switch_watchdog_correction"
+    assert level == "warning"
+    assert "Watchdog correcting mode" in message
+    assert args[0] == "Home UPS"
+    assert args[1] == "Home 1"
+    assert cooldown_s == auto_switch_module.WATCHDOG_WARNING_COOLDOWN_SECONDS
 
 
 @pytest.mark.asyncio

--- a/tests/test_init_setup_entry.py
+++ b/tests/test_init_setup_entry.py
@@ -217,6 +217,23 @@ class TrackingCoordinator:
         self.first_refresh_called = True
 
 
+class TrackingBoilerCoordinator:
+    def __init__(self):
+        self.first_refresh_called = False
+
+    async def async_config_entry_first_refresh(self):
+        self.first_refresh_called = True
+
+
+class FailingBoilerCoordinator:
+    def __init__(self):
+        self.first_refresh_called = False
+
+    async def async_config_entry_first_refresh(self):
+        self.first_refresh_called = True
+        raise RuntimeError("boiler boom")
+
+
 class TrackingBalancingManager:
     def __init__(self):
         self.forecast_sensor = None
@@ -423,6 +440,148 @@ async def test_complete_entry_startup_handles_dashboard_sync_failure(monkeypatch
         telemetry_store=None,
         battery_prediction_enabled=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_complete_entry_startup_refreshes_boiler_coordinator(monkeypatch):
+    hass = DummyHass()
+    entry = DummyEntry()
+    coordinator = TrackingCoordinator()
+    session_manager = DummySessionManager(DummyApi())
+    boiler_coordinator = TrackingBoilerCoordinator()
+
+    hass.data[DOMAIN] = {
+        entry.entry_id: {
+            "dashboard_enabled": False,
+            "boiler_coordinator": boiler_coordinator,
+        }
+    }
+
+    async def fake_init_notification_manager(*_args, **_kwargs):
+        return None
+
+    async def fake_init_balancing_manager(*_args, **_kwargs):
+        return None
+
+    async def fake_start_data_source_controller(*_args, **_kwargs):
+        return None
+
+    async def fake_sync_dashboard_panel(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        init_module,
+        "get_data_source_state",
+        lambda *_a, **_k: SimpleNamespace(effective_mode="local_only"),
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_init_notification_manager",
+        fake_init_notification_manager,
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_init_balancing_manager",
+        fake_init_balancing_manager,
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_start_data_source_controller",
+        fake_start_data_source_controller,
+    )
+    monkeypatch.setattr(init_module, "_sync_dashboard_panel", fake_sync_dashboard_panel)
+
+    await init_module._complete_entry_startup(
+        hass,
+        entry,
+        coordinator,
+        session_manager,
+        service_shield=None,
+        telemetry_store=None,
+        battery_prediction_enabled=False,
+    )
+
+    assert boiler_coordinator.first_refresh_called is True
+
+
+@pytest.mark.asyncio
+async def test_complete_entry_startup_continues_after_boiler_refresh_failure(monkeypatch):
+    hass = DummyHass()
+    entry = DummyEntry()
+    coordinator = TrackingCoordinator()
+    session_manager = DummySessionManager(DummyApi())
+    boiler_coordinator = FailingBoilerCoordinator()
+    balancing_manager = TrackingBalancingManager()
+    controller = object()
+    live_data_checked = {"called": False}
+    dashboard_synced = {"called": False}
+
+    hass.data[DOMAIN] = {
+        entry.entry_id: {
+            "dashboard_enabled": True,
+            "boiler_coordinator": boiler_coordinator,
+            "battery_forecast_sensors": ["forecast-sensor"],
+        }
+    }
+
+    async def fake_live_data_check(_api):
+        live_data_checked["called"] = True
+
+    async def fake_init_notification_manager(*_args, **_kwargs):
+        return "notification-manager"
+
+    async def fake_init_balancing_manager(*_args, **_kwargs):
+        return balancing_manager
+
+    async def fake_start_data_source_controller(*_args, **_kwargs):
+        return controller
+
+    async def fake_sync_dashboard_panel(_hass, _entry, enabled):
+        dashboard_synced["called"] = enabled
+
+    monkeypatch.setattr(
+        init_module,
+        "get_data_source_state",
+        lambda *_a, **_k: SimpleNamespace(
+            effective_mode=init_module.DATA_SOURCE_CLOUD_ONLY,
+        ),
+    )
+    monkeypatch.setattr(init_module, "_ensure_live_data_enabled", fake_live_data_check)
+    monkeypatch.setattr(
+        init_module,
+        "_init_notification_manager",
+        fake_init_notification_manager,
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_init_balancing_manager",
+        fake_init_balancing_manager,
+    )
+    monkeypatch.setattr(
+        init_module,
+        "_start_data_source_controller",
+        fake_start_data_source_controller,
+    )
+    monkeypatch.setattr(init_module, "_sync_dashboard_panel", fake_sync_dashboard_panel)
+
+    await init_module._complete_entry_startup(
+        hass,
+        entry,
+        coordinator,
+        session_manager,
+        service_shield=None,
+        telemetry_store=None,
+        battery_prediction_enabled=True,
+    )
+
+    assert boiler_coordinator.first_refresh_called is True
+    assert live_data_checked["called"] is True
+    assert hass.data[DOMAIN][entry.entry_id]["notification_manager"] == "notification-manager"
+    assert hass.data[DOMAIN][entry.entry_id]["balancing_manager"] is balancing_manager
+    assert hass.data[DOMAIN][entry.entry_id]["data_source_controller"] is controller
+    assert balancing_manager.forecast_sensor == "forecast-sensor"
+    assert balancing_manager.coordinator is coordinator
+    assert dashboard_synced["called"] is True
 
 
 @pytest.mark.asyncio
@@ -1956,7 +2115,7 @@ async def test_async_setup_entry_runtime_flags(
     assert (data.get("solar_forecast") is not None) is enable_solar
     assert (data.get("boiler_coordinator") is not None) is enable_boiler
     assert DummyOteApi.created == (1 if enable_pricing else 0)
-    assert DummyBoilerCoordinator.refresh_calls == (1 if enable_boiler else 0)
+    assert DummyBoilerCoordinator.refresh_calls == 0
     if enable_solar:
         assert data["solar_forecast"]["enabled"] is True
 

--- a/tests/test_simple_telemetry.py
+++ b/tests/test_simple_telemetry.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from custom_components.oig_cloud.shared.logging import SimpleTelemetry
+
+
+class DummyResponse:
+    def __init__(self, status: int, body: str):
+        self.status = status
+        self._body = body
+
+    async def text(self):
+        return self._body
+
+
+class DummyRequestContext:
+    def __init__(self, response: DummyResponse):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummySession:
+    closed = False
+
+    def __init__(self, response: DummyResponse):
+        self._response = response
+
+    def post(self, *args, **kwargs):
+        return DummyRequestContext(self._response)
+
+
+@pytest.mark.asyncio
+async def test_send_event_logs_info_once_for_expected_4xx(caplog):
+    telemetry = SimpleTelemetry("http://example.com", {})
+    telemetry.session = DummySession(DummyResponse(403, "forbidden"))
+
+    with caplog.at_level(logging.DEBUG):
+        result1 = await telemetry.send_event("change_requested", "svc", {})
+        result2 = await telemetry.send_event("change_requested", "svc", {})
+
+    assert result1 is False
+    assert result2 is False
+    assert "INFO" in caplog.text
+    assert "Failed to send change_requested: HTTP 403" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_send_event_logs_warning_for_unexpected_status(caplog):
+    telemetry = SimpleTelemetry("http://example.com", {})
+    telemetry.session = DummySession(DummyResponse(500, "boom"))
+
+    with caplog.at_level(logging.WARNING):
+        result = await telemetry.send_event("change_requested", "svc", {})
+
+    assert result is False
+    assert "Failed to send change_requested: HTTP 500" in caplog.text


### PR DESCRIPTION
## Summary
- defer boiler coordinator refresh out of the blocking setup path while keeping deferred startup completion resilient when boiler refresh fails
- make boiler sensors tolerate missing coordinator data during startup and remove the invalid boiler energy-needed sensor state-class metadata
- reduce repeated watchdog and expected telemetry warning spam so real runtime issues stand out in Home Assistant logs

## Verification
- `.venv/bin/pytest tests/test_init_setup_entry.py tests/test_balancing_manager_core.py tests/test_simple_telemetry.py tests/test_history_helpers.py tests/test_config_options_flow.py tests/test_config_steps_wizard_extra.py`
- `.venv/bin/python -m flake8 custom_components/oig_cloud tests --max-line-length=120`
- `.venv/bin/python -m compileall custom_components/oig_cloud tests`
