### PR TITLE
fix: ship 2.3.15 startup optimization hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.15] - 2026-04-04
+
+### Fixed
+- Startup now skips the custom coordinator jitter on the first refresh, including the cached-startup path, so initial coordinator updates no longer pay a random startup delay.
+- Sensor setup now keeps only the essential immediate groups in the blocking startup path while deferring computed sensors, reducing time to initial entity registration.
+- Deferred computed sensor registration now retries briefly when coordinator data is not ready yet, preventing those sensors from being skipped permanently on slow startup.
+
 ## [2.3.14] - 2026-04-04
 
 ### Fixed

--- a/custom_components/oig_cloud/__init__.py
+++ b/custom_components/oig_cloud/__init__.py
@@ -1106,6 +1106,8 @@ async def _init_session_manager_and_coordinator(
             and entry_state != ConfigEntryState.SETUP_IN_PROGRESS
             and hasattr(coordinator, "async_refresh")
         ):
+            if hasattr(coordinator, "skip_next_jitter"):
+                coordinator.skip_next_jitter()
             await coordinator.async_refresh()
         else:
             await coordinator.async_config_entry_first_refresh()

--- a/custom_components/oig_cloud/core/coordinator.py
+++ b/custom_components/oig_cloud/core/coordinator.py
@@ -94,6 +94,7 @@ class OigCloudCoordinator(DataUpdateCoordinator):
 
         # Last jitter value (for diagnostics/tests).
         self._next_jitter: Optional[float] = None
+        self._skip_next_jitter: bool = False
 
         # Startup grace period to avoid loading-heavy work during HA bootstrap
         self._startup_ts: datetime = self._utcnow()
@@ -195,6 +196,7 @@ class OigCloudCoordinator(DataUpdateCoordinator):
         while the coordinator is still doing the first network/local refresh.
         """
         await self.async_hydrate_startup_cache()
+        self.skip_next_jitter()
 
         try:
             await super().async_config_entry_first_refresh()
@@ -526,7 +528,13 @@ class OigCloudCoordinator(DataUpdateCoordinator):
         _LOGGER.debug("🔄 _async_update_data called - starting update cycle")
 
         # Apply jitter - random delay at start of update
-        jitter = self._calculate_jitter()
+        if self._skip_next_jitter:
+            self._skip_next_jitter = False
+            jitter = 0.0
+            self._next_jitter = jitter
+            _LOGGER.debug("⏱️  Skipping jitter for first refresh")
+        else:
+            jitter = self._calculate_jitter()
 
         # Only sleep for positive jitter (negative means update sooner, handled by next cycle)
         if jitter > 0:
@@ -578,6 +586,9 @@ class OigCloudCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(
                 f"Error communicating with OIG API: {exception}"
             ) from exception
+
+    def skip_next_jitter(self) -> None:
+        self._skip_next_jitter = True
 
     def _resolve_use_cloud(self) -> bool:
         use_cloud = True

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.14",
+  "version": "2.3.15",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/sensor.py
+++ b/custom_components/oig_cloud/sensor.py
@@ -14,6 +14,8 @@ from .entities.data_source_sensor import OigCloudDataSourceSensor
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFERRED_SENSOR_RETRY_DELAYS_S = (0.0, 0.5, 2.0)
+
 try:
     _LOGGER.debug("Attempting to import SENSOR_TYPES from sensor_types.py")
     from .sensor_types import SENSOR_TYPES
@@ -1474,36 +1476,47 @@ def _schedule_deferred_sensor_registration(
         return deferred_sensors
 
     async def _register_later() -> None:
-        await asyncio.sleep(0)
-        if not _entry_still_loaded():
-            _LOGGER.debug(
-                "Skipping deferred sensor registration because entry %s is no longer loaded",
-                entry_id,
-            )
+        for attempt, delay in enumerate(DEFERRED_SENSOR_RETRY_DELAYS_S, start=1):
+            await asyncio.sleep(delay)
+
+            if not _entry_still_loaded():
+                _LOGGER.debug(
+                    "Skipping deferred sensor registration because entry %s is no longer loaded",
+                    entry_id,
+                )
+                return
+
+            deferred_sensors = _build_deferred_sensors()
+
+            if not _entry_still_loaded():
+                _LOGGER.debug(
+                    "Skipping deferred sensor registration because entry %s was unloaded",
+                    entry_id,
+                )
+                return
+
+            if not deferred_sensors:
+                if attempt < len(DEFERRED_SENSOR_RETRY_DELAYS_S):
+                    _LOGGER.debug(
+                        "Deferred sensor registration yielded no sensors for entry %s; retrying (%s/%s)",
+                        entry_id,
+                        attempt,
+                        len(DEFERRED_SENSOR_RETRY_DELAYS_S),
+                    )
+                    continue
+                return
+
+            try:
+                _register_all_sensors(async_add_entities, deferred_sensors)
+            except Exception as err:
+                _LOGGER.warning(
+                    "Deferred sensor registration failed for entry %s: %s",
+                    entry_id,
+                    err,
+                    exc_info=True,
+                )
+                await asyncio.sleep(0)
             return
-
-        deferred_sensors = _build_deferred_sensors()
-
-        if not _entry_still_loaded():
-            _LOGGER.debug(
-                "Skipping deferred sensor registration because entry %s was unloaded",
-                entry_id,
-            )
-            return
-
-        if not deferred_sensors:
-            return
-
-        try:
-            _register_all_sensors(async_add_entities, deferred_sensors)
-        except Exception as err:
-            _LOGGER.warning(
-                "Deferred sensor registration failed for entry %s: %s",
-                entry_id,
-                err,
-                exc_info=True,
-            )
-            await asyncio.sleep(0)
 
     if getattr(hass, "loop", None) is None:
         if not _entry_still_loaded():
@@ -1591,7 +1604,7 @@ async def async_setup_entry(  # noqa: C901
     # Device: main_device_info (OIG Cloud {box_id})
     # Třída: OigCloudComputedSensor
     # ================================================================
-    core_sensors.extend(_create_computed_sensors(coordinator))
+    deferred_factories.append(lambda: _create_computed_sensors(coordinator))
     await asyncio.sleep(0)
 
     # ================================================================

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -249,6 +249,63 @@ async def test_async_update_data_jitter_positive(monkeypatch, coordinator, mock_
 
 
 @pytest.mark.asyncio
+async def test_async_update_data_skips_one_shot_jitter(monkeypatch, coordinator, mock_api):
+    mock_api.get_stats = AsyncMock(return_value={})
+    coordinator._startup_grace_seconds = 0
+    coordinator._skip_next_jitter = True
+    sleeps = []
+
+    async def _sleep(seconds):
+        sleeps.append(seconds)
+
+    def _unexpected_uniform(*_args, **_kwargs):
+        raise AssertionError("random.uniform should not be called when skipping jitter")
+
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.core.coordinator.random.uniform",
+        _unexpected_uniform,
+    )
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.core.coordinator.asyncio.sleep", _sleep
+    )
+
+    await coordinator._async_update_data()
+
+    assert sleeps == []
+    assert coordinator._skip_next_jitter is False
+    assert coordinator._next_jitter == 0.0
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_applies_jitter_after_one_shot_skip(
+    monkeypatch, coordinator, mock_api
+):
+    mock_api.get_stats = AsyncMock(return_value={})
+    coordinator._startup_grace_seconds = 0
+    coordinator._skip_next_jitter = True
+    sleeps = []
+    jitter_values = iter([2.0])
+
+    async def _sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.core.coordinator.random.uniform",
+        lambda *_a, **_k: next(jitter_values),
+    )
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.core.coordinator.asyncio.sleep", _sleep
+    )
+
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+
+    assert sleeps == [2.0]
+    assert coordinator._skip_next_jitter is False
+    assert coordinator._next_jitter == 2.0
+
+
+@pytest.mark.asyncio
 async def test_async_update_data_data_source_state_exception(monkeypatch, coordinator):
     coordinator._startup_grace_seconds = 0
     monkeypatch.setattr(coordinator, "_try_get_stats", AsyncMock(return_value={}))
@@ -2145,6 +2202,7 @@ async def test_async_config_entry_first_refresh_cache_load(monkeypatch, coordina
     await coordinator.async_config_entry_first_refresh()
 
     assert coordinator.data["foo"]["bar"] == 1
+    assert coordinator._skip_next_jitter is True
 
 
 @pytest.mark.asyncio
@@ -2160,6 +2218,8 @@ async def test_async_config_entry_first_refresh_cache_load_error(monkeypatch, co
     )
 
     await coordinator.async_config_entry_first_refresh()
+
+    assert coordinator._skip_next_jitter is True
 
 
 @pytest.mark.asyncio
@@ -2182,6 +2242,7 @@ async def test_async_config_entry_first_refresh_failure_with_cache(
     await coordinator.async_config_entry_first_refresh()
 
     assert coordinator.last_update_success is True
+    assert coordinator._skip_next_jitter is True
 
 
 @pytest.mark.asyncio
@@ -2199,3 +2260,5 @@ async def test_async_config_entry_first_refresh_failure_no_cache(
 
     with pytest.raises(RuntimeError):
         await coordinator.async_config_entry_first_refresh()
+
+    assert coordinator._skip_next_jitter is True

--- a/tests/test_init_setup_entry.py
+++ b/tests/test_init_setup_entry.py
@@ -134,6 +134,7 @@ class DummyCoordinatorWithRefresh(DummyCoordinator):
         self.first_refresh_called = False
         self.refresh_called = False
         self.hydrate_called = False
+        self.skip_next_jitter_called = False
 
     async def async_config_entry_first_refresh(self):
         self.first_refresh_called = True
@@ -142,6 +143,9 @@ class DummyCoordinatorWithRefresh(DummyCoordinator):
     async def async_refresh(self):
         self.refresh_called = True
         return None
+
+    def skip_next_jitter(self):
+        self.skip_next_jitter_called = True
 
     async def async_hydrate_startup_cache(self):
         self.hydrate_called = True
@@ -950,6 +954,7 @@ async def test_init_session_manager_uses_first_refresh_during_setup(monkeypatch)
 
     assert coordinator.first_refresh_called is True
     assert coordinator.refresh_called is False
+    assert coordinator.skip_next_jitter_called is False
 
 
 @pytest.mark.asyncio
@@ -993,6 +998,7 @@ async def test_init_session_manager_defers_refresh_during_setup_when_cache_avail
     assert coordinator.hydrate_called is True
     assert coordinator.first_refresh_called is False
     assert coordinator.refresh_called is False
+    assert coordinator.skip_next_jitter_called is False
 
 
 @pytest.mark.asyncio
@@ -1039,6 +1045,7 @@ async def test_init_session_manager_uses_first_refresh_when_only_box_id_exists(
     assert coordinator.hydrate_called is True
     assert coordinator.first_refresh_called is True
     assert coordinator.refresh_called is False
+    assert coordinator.skip_next_jitter_called is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor_setup_entry.py
+++ b/tests/test_sensor_setup_entry.py
@@ -176,6 +176,92 @@ async def test_sensor_async_setup_entry(monkeypatch):
     assert all(getattr(entity, "_attr_has_entity_name", None) is False for entity in added)
 
 
+@pytest.mark.asyncio
+async def test_sensor_async_setup_entry_defers_noncritical_groups(monkeypatch):
+    entry = DummyEntry()
+
+    class LoopHass(DummyHass):
+        def __init__(self, entry_id):
+            super().__init__(entry_id)
+            self.loop = object()
+            self.tasks = []
+
+        def async_create_task(self, coro):
+            self.tasks.append(coro)
+            return coro
+
+    hass = LoopHass(entry.entry_id)
+    added = []
+
+    monkeypatch.setattr(sensor_module, "resolve_box_id", lambda _c: "123")
+    monkeypatch.setattr(sensor_module, "_register_data_source_sensor", lambda *_a, **_k: [DummySensor()])
+    monkeypatch.setattr(sensor_module, "_create_basic_sensors", lambda *_a, **_k: [DummySensor()])
+    monkeypatch.setattr(sensor_module, "_create_computed_sensors", lambda *_a, **_k: [DummySensor()])
+    monkeypatch.setattr(sensor_module, "_create_shield_sensors", lambda *_a, **_k: [DummySensor()])
+    monkeypatch.setattr(sensor_module, "_create_notification_sensors", lambda *_a, **_k: [DummySensor()])
+    monkeypatch.setattr(sensor_module, "_create_extended_sensors", lambda *_a, **_k: [])
+    monkeypatch.setattr(sensor_module, "_create_statistics_sensors", lambda *_a, **_k: [])
+    monkeypatch.setattr(sensor_module, "_create_solar_forecast_sensors", lambda *_a, **_k: [])
+    monkeypatch.setattr(sensor_module, "_create_battery_prediction_sensors", lambda *_a, **_k: [])
+    monkeypatch.setattr(sensor_module, "_create_pricing_sensors", lambda *_a, **_k: [])
+    monkeypatch.setattr(sensor_module, "_create_chmu_sensors", lambda *_a, **_k: [])
+    monkeypatch.setattr(sensor_module, "_create_boiler_sensors", lambda *_a, **_k: [])
+
+    def _add_entities(entities, _update=False):
+        added.extend(entities)
+
+    await sensor_module.async_setup_entry(hass, entry, _add_entities)
+
+    assert len(added) == 4
+    assert len(hass.tasks) == 1
+
+    await hass.tasks[0]
+
+    assert len(added) == 5
+
+
+@pytest.mark.asyncio
+async def test_schedule_deferred_sensor_registration_retries_until_data_ready():
+    class LoopHass(DummyHass):
+        def __init__(self, entry_id):
+            super().__init__(entry_id)
+            self.loop = object()
+            self.tasks = []
+
+        def async_create_task(self, coro):
+            self.tasks.append(coro)
+            return coro
+
+    hass = LoopHass("entry1")
+    hass.data[DOMAIN]["entry1"]["coordinator"].data = None
+    added = []
+    attempts = {"count": 0}
+
+    def _add_entities(entities, _update=False):
+        added.extend(entities)
+
+    def _factory():
+        attempts["count"] += 1
+        if hass.data[DOMAIN]["entry1"]["coordinator"].data is None:
+            hass.data[DOMAIN]["entry1"]["coordinator"].data = {"123": {}}
+            return []
+        return [DummySensor()]
+
+    sensor_module._schedule_deferred_sensor_registration(
+        hass,
+        "entry1",
+        _add_entities,
+        [_factory],
+    )
+
+    assert len(hass.tasks) == 1
+
+    await hass.tasks[0]
+
+    assert attempts["count"] >= 2
+    assert len(added) == 1
+
+
 def test_apply_legacy_entity_naming_sets_short_name_mode():
     first = SimpleNamespace(entity_id="sensor.one", _attr_has_entity_name=True)
     second = SimpleNamespace(entity_id="sensor.two")


### PR DESCRIPTION
## Summary
- skip the custom coordinator jitter only for the first startup refresh, including the cached-startup path, so startup no longer pays a random delay before initial data arrives
- keep shield and notification sensors in the immediate setup path while deferring computed sensors with retry, reducing blocking sensor setup work without losing late-arriving computed entities
- bump the integration to 2.3.15 and document the startup optimization hotfixes in the changelog

## Verification
- `.venv/bin/pytest tests/test_init_setup_entry.py tests/test_sensor_setup_entry.py tests/test_history_helpers.py tests/test_balancing_manager_core.py tests/test_simple_telemetry.py tests/test_config_options_flow.py tests/test_config_steps_wizard_extra.py`
- `.venv/bin/python -m flake8 custom_components/oig_cloud tests --max-line-length=120`
- `.venv/bin/python -m compileall custom_components/oig_cloud tests`
