### PR TITLE
fix: runtime auth and recorder warning cleanup

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -44,7 +44,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
           pip install coverage
-          npm ci
+          npm ci --ignore-scripts
 
       - name: Run Python tests with coverage
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
       - name: Cache dependencies
         uses: actions/cache@v4
         with:
@@ -38,12 +44,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
           pip install coverage
+          npm ci
 
-      - name: Run tests with coverage
+      - name: Run Python tests with coverage
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           pytest -v --tb=short --cov=custom_components/oig_cloud --cov-report=xml --cov-report=term-missing:skip-covered
+
+      - name: Run frontend tests with coverage
+        run: |
+          npm run test:fe:unit:coverage
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
@@ -56,6 +67,7 @@ jobs:
             -Dsonar.organization=muriel2horak
             -Dsonar.sources=.
             -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
             -Dsonar.sourceEncoding=UTF-8
             -Dsonar.python.pylintConfigFile=.pylintrc
             -Dsonar.python.bandit.reportPaths=bandit-report.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.16] - 2026-04-05
+
+### Fixed
+- Legacy V1 dashboard API calls now prefer Home Assistant's authenticated `hass.callApi` path and no longer send unauthenticated fallback requests to `/api/oig_cloud/...`, reducing invalid-auth ban noise while preserving valid embedded dashboard flows.
+- Adaptive load profile statistics and battery efficiency fallback lookups now use Home Assistant recorder/statistics helper APIs via the recorder executor instead of direct database/session access, removing the remaining database-access warning paths.
+- Battery efficiency fallback now fills missing battery start/end bounds from recorder statistics even when charge/discharge history is already available, keeping monthly efficiency calculations consistent.
+
 ## [2.3.15] - 2026-04-04
 
 ### Fixed

--- a/custom_components/oig_cloud/battery_forecast/planning/charging_plan.py
+++ b/custom_components/oig_cloud/battery_forecast/planning/charging_plan.py
@@ -868,6 +868,221 @@ def _get_hour_from_interval(interval: dict) -> int:
         return -1
 
 
+def _get_interval_solar_kwh(interval: dict) -> float:
+    solar_kwh = interval.get("solar_production_kwh")
+    if solar_kwh is not None:
+        try:
+            return max(0.0, float(solar_kwh))
+        except (TypeError, ValueError):
+            return 0.0
+
+    solar_wh = interval.get("solar_wh")
+    if solar_wh is not None:
+        try:
+            return max(0.0, float(solar_wh) / 1000.0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    return 0.0
+
+
+def _get_interval_load_kwh(interval: dict) -> float:
+    try:
+        return max(0.0, float(interval.get("consumption_kwh", 0.0) or 0.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _get_interval_price_czk(interval: dict) -> Optional[float]:
+    try:
+        return float(interval.get("spot_price_czk", float("inf")))
+    except (TypeError, ValueError):
+        return None
+
+
+def _get_interval_grid_charge_kwh(interval: dict) -> float:
+    try:
+        return max(0.0, float(interval.get("grid_charge_kwh", 0.0) or 0.0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _project_soc_until_index(
+    *,
+    current_soc_kwh: float,
+    intervals: list[dict],
+    end_idx_exclusive: int,
+    round_trip_efficiency: float,
+    max_capacity_kwh: float,
+    extra_charge_by_index: Optional[dict[int, float]] = None,
+) -> tuple[float, float]:
+    if round_trip_efficiency <= 0:
+        return current_soc_kwh, current_soc_kwh
+
+    battery_soc = current_soc_kwh
+    min_soc = current_soc_kwh
+    extra_charge_by_index = extra_charge_by_index or {}
+
+    for idx, interval in enumerate(intervals[:end_idx_exclusive]):
+        solar_kwh = _get_interval_solar_kwh(interval)
+        load_kwh = _get_interval_load_kwh(interval)
+        grid_charge_kwh = _get_interval_grid_charge_kwh(interval) + extra_charge_by_index.get(idx, 0.0)
+
+        if grid_charge_kwh > 0.0:
+            battery_soc += solar_kwh + grid_charge_kwh
+        elif solar_kwh >= load_kwh:
+            battery_soc += solar_kwh - load_kwh
+        else:
+            battery_soc -= (load_kwh - solar_kwh) / round_trip_efficiency
+
+        battery_soc = max(0.0, min(max_capacity_kwh, battery_soc))
+        min_soc = min(min_soc, battery_soc)
+
+    return battery_soc, min_soc
+
+
+def _estimate_soc_after_peak_window(
+    *,
+    current_soc_kwh: float,
+    intervals: list[dict],
+    peak_end_idx: int,
+    round_trip_efficiency: float,
+    max_capacity_kwh: float,
+) -> float:
+    projected_soc, _ = _project_soc_until_index(
+        current_soc_kwh=current_soc_kwh,
+        intervals=intervals,
+        end_idx_exclusive=peak_end_idx + 1,
+        round_trip_efficiency=round_trip_efficiency,
+        max_capacity_kwh=max_capacity_kwh,
+    )
+    return projected_soc
+
+
+def _find_cheapest_future_interval(
+    intervals: list[dict],
+    *,
+    start_idx: int,
+) -> tuple[Optional[int], Optional[float]]:
+    cheapest_idx: Optional[int] = None
+    cheapest_price: Optional[float] = None
+    for idx in range(start_idx, len(intervals)):
+        price = _get_interval_price_czk(intervals[idx])
+        if price is None:
+            continue
+        if cheapest_price is None or price < cheapest_price:
+            cheapest_price = price
+            cheapest_idx = idx
+    return cheapest_idx, cheapest_price
+
+
+def _has_future_negative_price_headroom_risk(
+    intervals: list[dict],
+    *,
+    start_idx: int,
+    current_soc_kwh: float,
+    round_trip_efficiency: float,
+    max_capacity_kwh: float,
+    hw_min_soc_kwh: float,
+    extra_charge_by_index: Optional[dict[int, float]] = None,
+) -> bool:
+    tolerance = 1e-9
+
+    for idx in range(start_idx, len(intervals)):
+        interval = intervals[idx]
+        price = _get_interval_price_czk(interval)
+        if price is None or price >= 0.0:
+            continue
+
+        future_surplus_kwh = max(0.0, _get_interval_solar_kwh(interval) - _get_interval_load_kwh(interval))
+        if future_surplus_kwh <= 0.0:
+            continue
+
+        soc_without, min_soc_without = _project_soc_until_index(
+            current_soc_kwh=current_soc_kwh,
+            intervals=intervals,
+            end_idx_exclusive=idx,
+            round_trip_efficiency=round_trip_efficiency,
+            max_capacity_kwh=max_capacity_kwh,
+        )
+        if min_soc_without < hw_min_soc_kwh:
+            continue
+
+        soc_with, _ = _project_soc_until_index(
+            current_soc_kwh=current_soc_kwh,
+            intervals=intervals,
+            end_idx_exclusive=idx,
+            round_trip_efficiency=round_trip_efficiency,
+            max_capacity_kwh=max_capacity_kwh,
+            extra_charge_by_index=extra_charge_by_index,
+        )
+
+        headroom_without = max(0.0, max_capacity_kwh - soc_without)
+        headroom_with = max(0.0, max_capacity_kwh - soc_with)
+        if (
+            headroom_without + tolerance >= future_surplus_kwh
+            and headroom_with + tolerance < future_surplus_kwh
+        ):
+            return True
+
+    return False
+
+
+def _select_pre_peak_intervals(
+    *,
+    pre_peak_intervals: list[tuple[int, dict]],
+    current_soc_kwh: float,
+    config: EconomicChargingPlanConfig,
+) -> tuple[list[int], float, float]:
+    target_soc = min(
+        config.hw_min_soc_kwh * 1.2,
+        config.max_capacity * config.max_charge_fraction,
+    )
+    needed_kwh = max(0.0, target_soc - current_soc_kwh)
+
+    available_intervals = []
+    for idx, interval in pre_peak_intervals:
+        if _get_interval_grid_charge_kwh(interval) > 0.0:
+            continue
+        price = _get_interval_price_czk(interval)
+        if price is None:
+            continue
+        available_intervals.append((idx, price))
+
+    available_intervals.sort(key=lambda item: item[1])
+
+    charge_per_interval = config.charging_power_kw / 4.0
+    selected_indices: list[int] = []
+    total_charge = 0.0
+
+    for idx, _price in available_intervals:
+        if total_charge >= needed_kwh:
+            break
+        selected_indices.append(idx)
+        total_charge += charge_per_interval
+
+    return selected_indices, min(total_charge, needed_kwh), charge_per_interval
+
+
+def _build_extra_charge_by_index(
+    *,
+    selected_indices: list[int],
+    actual_charge_kwh: float,
+    charge_per_interval: float,
+) -> dict[int, float]:
+    remaining_charge = actual_charge_kwh
+    charge_map: dict[int, float] = {}
+
+    for idx in selected_indices:
+        if remaining_charge <= 0.0:
+            break
+        planned_charge = min(charge_per_interval, remaining_charge)
+        charge_map[idx] = planned_charge
+        remaining_charge -= planned_charge
+
+    return charge_map
+
+
 def should_pre_charge_for_peak_avoidance(
     config: EconomicChargingPlanConfig,
     flags: RolloutFlags,
@@ -960,9 +1175,7 @@ def should_pre_charge_for_peak_avoidance(
         )
 
     # Step 5: PV-first check
-    total_solar_kwh = sum(
-        i.get("solar_wh", 0) / 1000 for _, i in pre_peak_intervals
-    )
+    total_solar_kwh = sum(_get_interval_solar_kwh(interval) for _, interval in pre_peak_intervals)
     if total_solar_kwh >= 0.5 and flags.pv_first_policy_enabled:
         return PrePeakDecision(
             should_charge=False,
@@ -975,9 +1188,16 @@ def should_pre_charge_for_peak_avoidance(
             pre_peak_avg_price=0.0,
         )
 
+    peak_start_idx = peak_intervals[0][0]
+    soc_at_peak_start, _ = _project_soc_until_index(
+        current_soc_kwh=current_soc_kwh,
+        intervals=intervals,
+        end_idx_exclusive=peak_start_idx,
+        round_trip_efficiency=config.round_trip_efficiency,
+        max_capacity_kwh=config.max_capacity,
+    )
+
     # Step 6 & 7: SOC sufficient check
-    # Estimate SOC at peak start (use current_soc_kwh as approximation)
-    soc_at_peak_start = current_soc_kwh
     soc_threshold = config.hw_min_soc_kwh * 1.1
     if soc_at_peak_start >= soc_threshold:
         return PrePeakDecision(
@@ -1010,6 +1230,86 @@ def should_pre_charge_for_peak_avoidance(
     peak_avg = sum(peak_prices) / len(peak_prices)
     pre_peak_avg = sum(pre_peak_prices) / len(pre_peak_prices)
 
+    selected_indices, actual_charge_kwh, charge_per_interval = _select_pre_peak_intervals(
+        pre_peak_intervals=pre_peak_intervals,
+        current_soc_kwh=current_soc_kwh,
+        config=config,
+    )
+    extra_charge_by_index = _build_extra_charge_by_index(
+        selected_indices=selected_indices,
+        actual_charge_kwh=actual_charge_kwh,
+        charge_per_interval=charge_per_interval,
+    )
+    peak_end_idx = peak_intervals[-1][0]
+
+    projected_soc_after_peak = _estimate_soc_after_peak_window(
+        current_soc_kwh=current_soc_kwh,
+        intervals=intervals,
+        peak_end_idx=peak_end_idx,
+        round_trip_efficiency=config.round_trip_efficiency,
+        max_capacity_kwh=config.max_capacity,
+    )
+    future_soc_without_charge, min_soc_without_charge = _project_soc_until_index(
+        current_soc_kwh=current_soc_kwh,
+        intervals=intervals,
+        end_idx_exclusive=peak_end_idx + 1,
+        round_trip_efficiency=config.round_trip_efficiency,
+        max_capacity_kwh=config.max_capacity,
+    )
+    survives_peak_without_precharge = min_soc_without_charge >= config.hw_min_soc_kwh
+
+    cheapest_future_idx, cheapest_future_price = _find_cheapest_future_interval(
+        intervals,
+        start_idx=peak_end_idx + 1,
+    )
+    if (
+        survives_peak_without_precharge
+        and actual_charge_kwh > 0.0
+        and _has_future_negative_price_headroom_risk(
+            intervals,
+            start_idx=peak_end_idx + 1,
+            current_soc_kwh=current_soc_kwh,
+            round_trip_efficiency=config.round_trip_efficiency,
+            max_capacity_kwh=config.max_capacity,
+            hw_min_soc_kwh=config.hw_min_soc_kwh,
+            extra_charge_by_index=extra_charge_by_index,
+        )
+    ):
+        return PrePeakDecision(
+            should_charge=False,
+            reason="future_negative_price_headroom",
+            soc_at_peak_start_kwh=soc_at_peak_start,
+            cheapest_intervals=[],
+            expected_charge_kwh=0.0,
+            estimated_saving_czk=0.0,
+            peak_avg_price=peak_avg,
+            pre_peak_avg_price=pre_peak_avg,
+        )
+
+    if (
+        cheapest_future_idx is not None
+        and actual_charge_kwh > 0.0
+        and cheapest_future_price is not None
+        and cheapest_future_price < pre_peak_avg
+        and _project_soc_until_index(
+            current_soc_kwh=current_soc_kwh,
+            intervals=intervals,
+            end_idx_exclusive=cheapest_future_idx,
+            round_trip_efficiency=config.round_trip_efficiency,
+            max_capacity_kwh=config.max_capacity,
+        )[1] >= config.hw_min_soc_kwh
+    ):
+        return PrePeakDecision(
+            should_charge=False,
+            reason="cheaper_post_peak_available",
+            soc_at_peak_start_kwh=soc_at_peak_start,
+            cheapest_intervals=[],
+            expected_charge_kwh=0.0,
+            estimated_saving_czk=0.0,
+            peak_avg_price=peak_avg,
+            pre_peak_avg_price=pre_peak_avg,
+        )
+
     # Breakeven calculation with round-trip efficiency
     breakeven = pre_peak_avg / config.round_trip_efficiency
     if peak_avg < breakeven * config.peak_price_ratio_threshold:
@@ -1024,40 +1324,7 @@ def should_pre_charge_for_peak_avoidance(
             pre_peak_avg_price=pre_peak_avg,
         )
 
-    # Step 9: Select cheapest intervals for charging
-    # Calculate target SOC (don't exceed max_capacity * max_charge_fraction)
-    target_soc = min(
-        config.hw_min_soc_kwh * 1.2,
-        config.max_capacity * config.max_charge_fraction
-    )
-    needed_kwh = max(0, target_soc - current_soc_kwh)
-
-    # Sort pre-peak intervals by price, filter out those with existing economic charging
-    available_intervals = []
-    for idx, interval in pre_peak_intervals:
-        existing_charge = interval.get("grid_charge_kwh", 0)
-        # Skip intervals that already have economic charging scheduled
-        if existing_charge > 0:
-            continue
-        price = interval.get("spot_price_czk", float("inf"))
-        available_intervals.append((idx, price))
-
-    # Sort by price (cheapest first)
-    available_intervals.sort(key=lambda x: x[1])
-
-    # Select cheapest intervals needed for charging
-    charge_per_interval = config.charging_power_kw / 4.0  # 15-minute intervals
-    selected_indices = []
-    total_charge = 0.0
-
-    for idx, price in available_intervals:
-        if total_charge >= needed_kwh:
-            break
-        selected_indices.append(idx)
-        total_charge += charge_per_interval
-
     # Step 10: Return positive decision
-    actual_charge_kwh = min(total_charge, needed_kwh)
     estimated_saving = (peak_avg - pre_peak_avg / config.round_trip_efficiency) * actual_charge_kwh
 
     return PrePeakDecision(

--- a/custom_components/oig_cloud/battery_forecast/planning/charging_plan.py
+++ b/custom_components/oig_cloud/battery_forecast/planning/charging_plan.py
@@ -1242,13 +1242,6 @@ def should_pre_charge_for_peak_avoidance(
     )
     peak_end_idx = peak_intervals[-1][0]
 
-    projected_soc_after_peak = _estimate_soc_after_peak_window(
-        current_soc_kwh=current_soc_kwh,
-        intervals=intervals,
-        peak_end_idx=peak_end_idx,
-        round_trip_efficiency=config.round_trip_efficiency,
-        max_capacity_kwh=config.max_capacity,
-    )
     future_soc_without_charge, min_soc_without_charge = _project_soc_until_index(
         current_soc_kwh=current_soc_kwh,
         intervals=intervals,

--- a/custom_components/oig_cloud/battery_forecast/sensors/efficiency_sensor.py
+++ b/custom_components/oig_cloud/battery_forecast/sensors/efficiency_sensor.py
@@ -19,8 +19,14 @@ _LOGGER = logging.getLogger(__name__)
 if TYPE_CHECKING:  # pragma: no cover
     from ...core.coordinator import OigCloudCoordinator
 
+    class _EfficiencyEntityBase(CoordinatorEntity):
+        pass
+else:
+    class _EfficiencyEntityBase(CoordinatorEntity, SensorEntity):
+        pass
 
-class OigCloudBatteryEfficiencySensor(CoordinatorEntity, SensorEntity):
+
+class OigCloudBatteryEfficiencySensor(_EfficiencyEntityBase):
     """
     Battery round-trip efficiency calculator.
 
@@ -422,7 +428,12 @@ async def _fallback_to_statistics(
     battery_end: Optional[float],
 ) -> tuple[Optional[float], Optional[float], Optional[float], Optional[float]]:
     """Fallback to statistics if history values are missing."""
-    if charge_wh is None or discharge_wh is None:
+    if (
+        charge_wh is None
+        or discharge_wh is None
+        or battery_start is None
+        or battery_end is None
+    ):
         stats_metrics = await _load_month_metrics_from_statistics(
             hass, start_utc, end_utc, charge_sensor, discharge_sensor, battery_sensor
         )
@@ -527,80 +538,59 @@ async def _load_month_metrics_from_statistics(
     battery_sensor: str,
 ) -> Optional[Dict[str, Optional[float]]]:
     try:
-        from homeassistant.components.recorder.db_schema import (
-            Statistics,
-            StatisticsMeta,
+        from homeassistant.components.recorder.statistics import (
+            statistics_during_period,
         )
-        from homeassistant.components.recorder.util import session_scope
+        from homeassistant.helpers.recorder import get_instance
     except ImportError:
         _LOGGER.warning("Recorder statistics not available")
         return None
 
-    start_ts = dt_util.as_timestamp(start_utc)
-    end_ts = dt_util.as_timestamp(end_utc)
     sensor_ids = {charge_sensor, discharge_sensor, battery_sensor}
+    try:
+        recorder_instance = get_instance(hass)
+    except (KeyError, AttributeError):
+        recorder_instance = None
+    if recorder_instance is None:
+        _LOGGER.warning("Recorder instance not available for efficiency statistics")
+        return None
 
-    def _query_stats() -> Dict[str, Optional[float]]:
-        try:
-            with session_scope(hass=hass) as session:
-                meta_rows = (
-                    session.query(StatisticsMeta.statistic_id, StatisticsMeta.id)
-                    .filter(StatisticsMeta.statistic_id.in_(sensor_ids))
-                    .all()
-                )
-                meta_map = {row[0]: row[1] for row in meta_rows}
+    try:
+        stats_by_sensor = await recorder_instance.async_add_executor_job(
+            statistics_during_period,
+            hass,
+            start_utc,
+            end_utc,
+            sensor_ids,
+            "hour",
+            None,
+            {"sum", "state", "mean"},
+        )
+    except Exception as err:
+        _LOGGER.warning("Efficiency stats query failed: %s", err)
+        return None
 
-                def _last_row(stat_id: str) -> Optional[Any]:
-                    meta_id = meta_map.get(stat_id)
-                    if not meta_id:
-                        return None
-                    return (
-                        session.query(Statistics)
-                        .filter(
-                            Statistics.metadata_id == meta_id,
-                            Statistics.start_ts >= start_ts,
-                            Statistics.start_ts < end_ts,
-                        )
-                        .order_by(Statistics.start_ts.desc())
-                        .first()
-                    )
+    def _first_row(stat_id: str) -> Optional[Any]:
+        rows = stats_by_sensor.get(stat_id) if stats_by_sensor else None
+        return rows[0] if rows else None
 
-                def _first_row(stat_id: str) -> Optional[Any]:
-                    meta_id = meta_map.get(stat_id)
-                    if not meta_id:
-                        return None
-                    return (
-                        session.query(Statistics)
-                        .filter(
-                            Statistics.metadata_id == meta_id,
-                            Statistics.start_ts >= start_ts,
-                            Statistics.start_ts < end_ts,
-                        )
-                        .order_by(Statistics.start_ts.asc())
-                        .first()
-                    )
+    def _last_row(stat_id: str) -> Optional[Any]:
+        rows = stats_by_sensor.get(stat_id) if stats_by_sensor else None
+        return rows[-1] if rows else None
 
-                result = {
-                    "charge_wh": _stat_value(_last_row(charge_sensor), True),
-                    "discharge_wh": _stat_value(_last_row(discharge_sensor), True),
-                    "battery_start_kwh": _stat_value(_first_row(battery_sensor), False),
-                    "battery_end_kwh": _stat_value(_last_row(battery_sensor), False),
-                }
-                _LOGGER.debug(
-                    "Efficiency stats lookup %s: charge=%s discharge=%s",
-                    start_utc.date(),
-                    result["charge_wh"],
-                    result["discharge_wh"],
-                )
-                return result
-        except Exception as err:
-            _LOGGER.warning("Efficiency stats query failed: %s", err)
-            return {}
-
-    stats = await hass.async_add_executor_job(_query_stats)
-    if not stats or (
-        stats.get("charge_wh") is None and stats.get("discharge_wh") is None
-    ):
+    stats = {
+        "charge_wh": _stat_value(_last_row(charge_sensor), True),
+        "discharge_wh": _stat_value(_last_row(discharge_sensor), True),
+        "battery_start_kwh": _stat_value(_first_row(battery_sensor), False),
+        "battery_end_kwh": _stat_value(_last_row(battery_sensor), False),
+    }
+    _LOGGER.debug(
+        "Efficiency stats lookup %s: charge=%s discharge=%s",
+        start_utc.date(),
+        stats["charge_wh"],
+        stats["discharge_wh"],
+    )
+    if stats.get("charge_wh") is None and stats.get("discharge_wh") is None:
         return None
     return stats
 
@@ -650,7 +640,7 @@ def _compute_metrics_from_wh(
     discharge_wh: Optional[float],
     battery_start_kwh: Optional[float],
     battery_end_kwh: Optional[float],
-) -> Optional[Dict[str, float]]:
+) -> Optional[Dict[str, Optional[float]]]:
     if charge_wh is None or discharge_wh is None:
         return None
 
@@ -719,7 +709,7 @@ def _empty_metrics(
 
 
 def _log_last_month_success(
-    last_month: int, last_month_year: int, metrics: Dict[str, float]
+    last_month: int, last_month_year: int, metrics: Dict[str, Optional[float]]
 ) -> None:
     delta_kwh = metrics.get("delta_kwh")
     delta_label = f"{delta_kwh:.2f}" if delta_kwh is not None else "n/a"

--- a/custom_components/oig_cloud/entities/adaptive_load_profiles_sensor.py
+++ b/custom_components/oig_cloud/entities/adaptive_load_profiles_sensor.py
@@ -357,46 +357,61 @@ class OigCloudAdaptiveLoadProfilesSensor(CoordinatorEntity, SensorEntity):
     def _query_hourly_statistics(
         self, sensor_entity_id: str, start_ts: int, end_ts: int
     ):
-        """Query statistics rows for hourly values."""
-        from homeassistant.helpers.recorder import get_instance, session_scope
-        from sqlalchemy import text
+        from homeassistant.components.recorder.statistics import statistics_during_period
 
-        instance = get_instance(self._hass)
-        with session_scope(hass=self._hass, session=instance.get_session()) as session:
-            query = text(
-                """
-                SELECT s.sum, s.mean, s.state, s.start_ts
-                FROM statistics s
-                INNER JOIN statistics_meta sm ON s.metadata_id = sm.id
-                WHERE sm.statistic_id = :statistic_id
-                AND s.start_ts >= :start_ts
-                AND s.start_ts < :end_ts
-                ORDER BY s.start_ts
-                """
-            )
-            result = session.execute(
-                query,
-                {
-                    "statistic_id": sensor_entity_id,
-                    "start_ts": start_ts,
-                    "end_ts": end_ts,
-                },
-            )
-            return result.fetchall()
+        start_time = datetime.fromtimestamp(start_ts, tz=dt_util.UTC)
+        end_time = datetime.fromtimestamp(end_ts, tz=dt_util.UTC)
+        stats = statistics_during_period(
+            self._hass,
+            start_time,
+            end_time,
+            {sensor_entity_id},
+            "hour",
+            None,
+            {"sum", "mean", "state"},
+        )
+        return stats.get(sensor_entity_id, []) if stats else []
+
+    @staticmethod
+    def _coerce_stat_timestamp(value: Any) -> Optional[datetime]:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=dt_util.UTC)
+        if isinstance(value, str):
+            parsed = dt_util.parse_datetime(value)
+            if parsed:
+                return parsed if parsed.tzinfo else parsed.replace(tzinfo=dt_util.UTC)
+            return None
+        if isinstance(value, (int, float)):
+            timestamp = float(value)
+            if timestamp > 1_000_000_000_000:
+                timestamp /= 1000.0
+            return datetime.fromtimestamp(timestamp, tz=dt_util.UTC)
+        return None
 
     def _parse_hourly_row(
         self, row: Tuple[Any, ...], value_field: str, unit_factor: float
     ) -> Optional[Tuple[datetime, float]]:
         """Normalize a statistics row into a local timestamp and value."""
-        try:
-            sum_val = row[0]
-            mean_val = row[1]
-            state_val = row[2]
-            timestamp_ts = float(row[3])
-        except (ValueError, AttributeError, IndexError, TypeError):
-            return None
+        if isinstance(row, dict):
+            sum_val = row.get("sum")
+            mean_val = row.get("mean")
+            state_val = row.get("state")
+            timestamp = self._coerce_stat_timestamp(
+                row.get("start") or row.get("start_time")
+            )
+            if timestamp is None:
+                return None
+        else:
+            try:
+                sum_val = row[0]
+                mean_val = row[1]
+                state_val = row[2]
+                timestamp = datetime.fromtimestamp(float(row[3]), tz=dt_util.UTC)
+            except (ValueError, AttributeError, IndexError, TypeError):
+                return None
 
-        timestamp = datetime.fromtimestamp(timestamp_ts, tz=dt_util.UTC)
         if value_field == "mean":
             if mean_val is None:
                 return None
@@ -466,35 +481,40 @@ class OigCloudAdaptiveLoadProfilesSensor(CoordinatorEntity, SensorEntity):
             return None
 
         try:
-            from homeassistant.helpers.recorder import get_instance, session_scope
-            from sqlalchemy import text
+            from homeassistant.components.recorder.statistics import (
+                statistics_during_period,
+            )
+            from homeassistant.helpers.recorder import get_instance
 
             recorder_instance = get_instance(self._hass)
             if not recorder_instance:
                 _LOGGER.error("Recorder instance not available")
                 return None
 
-            def get_min_start_ts() -> Optional[float]:
-                instance = get_instance(self._hass)
-                with session_scope(
-                    hass=self._hass, session=instance.get_session()
-                ) as session:
-                    query = text(
-                        """
-                        SELECT MIN(s.start_ts)
-                        FROM statistics s
-                        INNER JOIN statistics_meta sm ON s.metadata_id = sm.id
-                        WHERE sm.statistic_id = :statistic_id
-                        """
-                    )
-                    result = session.execute(query, {"statistic_id": sensor_entity_id})
-                    return result.scalar()
+            def get_earliest_stat_start() -> Optional[datetime]:
+                stats = statistics_during_period(
+                    self._hass,
+                    datetime.fromtimestamp(0, tz=dt_util.UTC),
+                    dt_util.utcnow(),
+                    {sensor_entity_id},
+                    "day",
+                    None,
+                    {"sum", "mean", "state"},
+                )
+                rows = stats.get(sensor_entity_id) if stats else None
+                if not rows:
+                    return None
+                first_row = rows[0]
+                return self._coerce_stat_timestamp(
+                    first_row.get("start") or first_row.get("start_time")
+                )
 
-            min_ts = await recorder_instance.async_add_executor_job(get_min_start_ts)
-            if min_ts is None:
+            earliest = await recorder_instance.async_add_executor_job(
+                get_earliest_stat_start
+            )
+            if earliest is None:
                 return None
 
-            earliest = datetime.fromtimestamp(float(min_ts), tz=dt_util.UTC)
             local = dt_util.as_local(earliest)
             return datetime.combine(
                 local.date(), datetime.min.time(), tzinfo=local.tzinfo

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.15",
+  "version": "2.3.16",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/www/js/core/api.js
+++ b/custom_components/oig_cloud/www/js/core/api.js
@@ -60,8 +60,39 @@ async function fetchWithAuth(url, options = {}) {
         throw new Error('Nepovoleno: fetchWithAuth je pouze pro HA API (/api/...). Absolutní URL nejsou bezpečné.');
     }
 
+    if (url.startsWith('/api/')) {
+        const hass = getHass();
+        if (hass && typeof hass.callApi === 'function') {
+            const resolvedUrl = new URL(url, globalThis.location.href);
+            const endpoint = `${resolvedUrl.pathname.slice('/api/'.length)}${resolvedUrl.search}`;
+            const method = (options.method || 'GET').toUpperCase();
+            let payload;
+
+            if (options.body !== undefined && options.body !== null && method !== 'GET') {
+                if (typeof options.body === 'string') {
+                    payload = options.body ? JSON.parse(options.body) : undefined;
+                } else {
+                    payload = options.body;
+                }
+            }
+
+            const result = await hass.callApi(method, endpoint, payload);
+            return {
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                json: async () => result,
+                text: async () => JSON.stringify(result)
+            };
+        }
+    }
+
     const token = getHAToken();
     const mergedHeaders = options.headers ? { ...options.headers } : {};
+
+    if (!token && url.startsWith('/api/')) {
+        throw new Error('No Home Assistant access token available for authenticated API request.');
+    }
 
     if (token && !mergedHeaders.Authorization && !mergedHeaders.authorization) {
         mergedHeaders.Authorization = `Bearer ${token}`;
@@ -71,6 +102,14 @@ async function fetchWithAuth(url, options = {}) {
         ...options,
         headers: mergedHeaders
     });
+}
+
+function getAuthenticatedFetch() {
+    const authFetch = globalThis.DashboardAPI?.fetchWithAuth || globalThis.fetchWithAuth;
+    if (typeof authFetch !== 'function') {
+        throw new Error('Authenticated HA fetch helper is not available.');
+    }
+    return authFetch;
 }
 
 // ============================================================================
@@ -460,15 +499,9 @@ const PlannerState = (() => {
                 if (hass && typeof hass.callApi === 'function') {
                     payload = await hass.callApi('GET', endpoint);
                 } else {
-                    const headers = { 'Content-Type': 'application/json' };
-                    const token = globalThis.DashboardAPI?.getHAToken?.();
-                    if (token) {
-                        headers.Authorization = `Bearer ${token}`;
-                    }
-
-                    const response = await fetch(`/api/${endpoint}`, {
+                    const response = await getAuthenticatedFetch()(`/api/${endpoint}`, {
                         method: 'GET',
-                        headers,
+                        headers: { 'Content-Type': 'application/json' },
                         credentials: 'same-origin'
                     });
 
@@ -494,8 +527,7 @@ const PlannerState = (() => {
     };
 
     const getDefaultPlan = async (force = false) => {
-        const settings = await fetchSettings(force);
-        return resolveActivePlan(settings);
+        return resolveActivePlan(await fetchSettings(force));
     };
 
     const getCachedSettings = () => cache;

--- a/custom_components/oig_cloud/www/js/core/api.js
+++ b/custom_components/oig_cloud/www/js/core/api.js
@@ -486,7 +486,7 @@ const PlannerState = (() => {
         }
 
         inflight = (async () => {
-            if (!globalThis.INVERTER_SN) {
+            if (!INVERTER_SN) {
                 return null;
             }
 
@@ -532,12 +532,19 @@ const PlannerState = (() => {
 
     const getCachedSettings = () => cache;
 
+    const invalidate = () => {
+        cache = null;
+        lastFetch = 0;
+        inflight = null;
+    };
+
     const getLabels = (plan = 'hybrid') => PLAN_LABELS[plan] || PLAN_LABELS.hybrid;
 
     return {
         fetchSettings,
         getDefaultPlan,
         getCachedSettings,
+        invalidate,
         resolveActivePlan,
         getLabels
     };

--- a/custom_components/oig_cloud/www/js/features/timeline.js
+++ b/custom_components/oig_cloud/www/js/features/timeline.js
@@ -418,17 +418,14 @@ class TimelineDialog {
             return hass.callApi(method, endpoint, method === 'GET' ? undefined : payload || {});
         }
 
-        const headers = { 'Content-Type': 'application/json' };
-        const token = globalThis.DashboardAPI?.getHAToken?.();
-        if (token) {
-            headers.Authorization = `Bearer ${token}`;
-        } else {
-            console.warn('[TimelineDialog] HA token not available, relying on cookies for auth');
+        const authFetch = globalThis.DashboardAPI?.fetchWithAuth || globalThis.fetchWithAuth;
+        if (typeof authFetch !== 'function') {
+            throw new Error('Authenticated HA fetch helper is not available');
         }
 
-        const response = await fetch(`/api/${endpoint}`, {
+        const response = await authFetch(`/api/${endpoint}`, {
             method,
-            headers,
+            headers: { 'Content-Type': 'application/json' },
             body: method === 'GET' ? undefined : JSON.stringify(payload || {}),
             credentials: 'same-origin'
         });

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
       "include": [
         "tests/fe/unit/**/*.test.js"
       ]
-    },
-    "coverage": {
-      "provider": "v8"
     }
   },
   "devDependencies": {

--- a/tests/fe/unit/api.test.js
+++ b/tests/fe/unit/api.test.js
@@ -21,6 +21,8 @@ describe('Dashboard API auth handling', () => {
     globalThis.fetch = vi.fn();
     globalThis.INVERTER_SN = '123';
     setParentQueryResult(null);
+    globalThis.DashboardAPI.setInverterSN('123');
+    globalThis.PlannerState.invalidate();
   });
 
   it('blocks authenticated HA API requests when token is missing', async () => {
@@ -90,6 +92,7 @@ describe('Dashboard API auth handling', () => {
       undefined
     );
     await expect(response.json()).resolves.toEqual({ today: [] });
+    await expect(response.text()).resolves.toBe(JSON.stringify({ today: [] }));
   });
 
   it('passes parsed JSON body to hass.callApi for non-GET HA API requests', async () => {
@@ -153,5 +156,170 @@ describe('Dashboard API auth handling', () => {
       globalThis.DashboardAPI.fetchWithAuth = originalDashboardFetch;
       globalThis.fetchWithAuth = originalGlobalFetchWithAuth;
     }
+  });
+
+  it('returns null when PlannerState has no inverter serial number', async () => {
+    globalThis.DashboardAPI.setInverterSN('');
+
+    await expect(globalThis.PlannerState.fetchSettings(true)).resolves.toBeNull();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('uses hass.callApi for PlannerState when available', async () => {
+    const callApi = vi.fn().mockResolvedValue({ mode: 'hybrid' });
+    setParentQueryResult({
+      hass: {
+        callApi,
+        auth: {
+          data: {}
+        }
+      }
+    });
+
+    await expect(globalThis.PlannerState.fetchSettings(true)).resolves.toEqual({ mode: 'hybrid' });
+    expect(callApi).toHaveBeenCalledWith('GET', 'oig_cloud/battery_forecast/123/planner_settings');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('uses authenticated fetch fallback for PlannerState success path', async () => {
+    setParentQueryResult({
+      hass: {
+        auth: {
+          data: {
+            access_token: 'token-123'
+          }
+        }
+      }
+    });
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ mode: 'hybrid' })
+    });
+
+    const result = await globalThis.PlannerState.fetchSettings(true);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/oig_cloud/battery_forecast/123/planner_settings',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-123'
+        })
+      })
+    );
+    expect(result).toEqual({ mode: 'hybrid' });
+  });
+
+  it('reuses cached PlannerState settings without refetch when force is false', async () => {
+    setParentQueryResult({
+      hass: {
+        auth: {
+          data: {
+            access_token: 'token-123'
+          }
+        }
+      }
+    });
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ mode: 'hybrid' })
+    });
+
+    await expect(globalThis.PlannerState.fetchSettings(true)).resolves.toEqual({ mode: 'hybrid' });
+    await expect(globalThis.PlannerState.fetchSettings(false)).resolves.toEqual({ mode: 'hybrid' });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the inflight PlannerState request across callers', async () => {
+    setParentQueryResult({
+      hass: {
+        auth: {
+          data: {
+            access_token: 'token-123'
+          }
+        }
+      }
+    });
+
+    let resolveResponse;
+    globalThis.fetch.mockImplementation(
+      () => new Promise((resolve) => {
+        resolveResponse = resolve;
+      })
+    );
+
+    const first = globalThis.PlannerState.fetchSettings(true);
+    const second = globalThis.PlannerState.fetchSettings(false);
+
+    resolveResponse({
+      ok: true,
+      json: async () => ({ mode: 'hybrid' })
+    });
+
+    await expect(first).resolves.toEqual({ mode: 'hybrid' });
+    await expect(second).resolves.toEqual({ mode: 'hybrid' });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when authenticated PlannerState fallback gets non-ok response', async () => {
+    setParentQueryResult({
+      hass: {
+        auth: {
+          data: {
+            access_token: 'token-123'
+          }
+        }
+      }
+    });
+    globalThis.fetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await globalThis.PlannerState.fetchSettings(true);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns the default hybrid plan label from PlannerState', async () => {
+    setParentQueryResult({
+      hass: {
+        auth: {
+          data: {
+            access_token: 'token-123'
+          }
+        }
+      }
+    });
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ mode: 'hybrid' })
+    });
+
+    await expect(globalThis.PlannerState.getDefaultPlan(true)).resolves.toBe('hybrid');
+    expect(globalThis.PlannerState.getCachedSettings()).toEqual({ mode: 'hybrid' });
+    expect(globalThis.PlannerState.getLabels('missing')).toEqual({ short: 'Plán', long: 'Plánování' });
+  });
+
+  it('clears cached PlannerState settings when invalidated', async () => {
+    setParentQueryResult({
+      hass: {
+        auth: {
+          data: {
+            access_token: 'token-123'
+          }
+        }
+      }
+    });
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ mode: 'hybrid' })
+    });
+
+    await globalThis.PlannerState.fetchSettings(true);
+    expect(globalThis.PlannerState.getCachedSettings()).toEqual({ mode: 'hybrid' });
+
+    globalThis.PlannerState.invalidate();
+
+    expect(globalThis.PlannerState.getCachedSettings()).toBeNull();
   });
 });

--- a/tests/fe/unit/api.test.js
+++ b/tests/fe/unit/api.test.js
@@ -91,4 +91,67 @@ describe('Dashboard API auth handling', () => {
     );
     await expect(response.json()).resolves.toEqual({ today: [] });
   });
+
+  it('passes parsed JSON body to hass.callApi for non-GET HA API requests', async () => {
+    const callApi = vi.fn().mockResolvedValue({ ok: true });
+    setParentQueryResult({
+      hass: {
+        callApi,
+        auth: {
+          data: {}
+        }
+      }
+    });
+
+    const response = await globalThis.DashboardAPI.fetchWithAuth(
+      '/api/oig_cloud/battery_forecast/123/timeline',
+      {
+        method: 'POST',
+        body: JSON.stringify({ plan: 'hybrid', day: 'today' })
+      }
+    );
+
+    expect(callApi).toHaveBeenCalledWith(
+      'POST',
+      'oig_cloud/battery_forecast/123/timeline',
+      { plan: 'hybrid', day: 'today' }
+    );
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it('passes object body through to hass.callApi unchanged', async () => {
+    const callApi = vi.fn().mockResolvedValue({ ok: true });
+    const body = { plan: 'hybrid', force: true };
+    setParentQueryResult({
+      hass: {
+        callApi,
+        auth: {
+          data: {}
+        }
+      }
+    });
+
+    await globalThis.DashboardAPI.fetchWithAuth('/api/oig_cloud/test-endpoint', {
+      method: 'POST',
+      body
+    });
+
+    expect(callApi).toHaveBeenCalledWith('POST', 'oig_cloud/test-endpoint', body);
+  });
+
+  it('throws when authenticated fetch helper is missing for PlannerState fallback', async () => {
+    const originalDashboardFetch = globalThis.DashboardAPI.fetchWithAuth;
+    const originalGlobalFetchWithAuth = globalThis.fetchWithAuth;
+
+    globalThis.DashboardAPI.fetchWithAuth = undefined;
+    globalThis.fetchWithAuth = undefined;
+
+    try {
+      const result = await globalThis.PlannerState.fetchSettings(true);
+      expect(result).toBeNull();
+    } finally {
+      globalThis.DashboardAPI.fetchWithAuth = originalDashboardFetch;
+      globalThis.fetchWithAuth = originalGlobalFetchWithAuth;
+    }
+  });
 });

--- a/tests/fe/unit/api.test.js
+++ b/tests/fe/unit/api.test.js
@@ -280,6 +280,100 @@ describe('Dashboard API auth handling', () => {
     expect(result).toBeNull();
   });
 
+  it('blocks non-/api absolute URLs in fetchWithAuth', async () => {
+    await expect(
+      globalThis.DashboardAPI.fetchWithAuth('https://evil.com/api/data')
+    ).rejects.toThrow('Nepovoleno: fetchWithAuth je pouze pro HA API');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing Authorization header in fetchWithAuth', async () => {
+    setParentQueryResult({
+      hass: {
+        auth: {
+          data: {
+            access_token: 'token-123'
+          }
+        }
+      }
+    });
+    globalThis.fetch.mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
+
+    await globalThis.DashboardAPI.fetchWithAuth('/api/oig_cloud/test', {
+      headers: {
+        Authorization: 'Bearer existing-token'
+      }
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/oig_cloud/test',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer existing-token'
+        })
+      })
+    );
+  });
+
+  it('falls back to raw fetch when hass exists but callApi is unavailable', async () => {
+    setParentQueryResult({
+      hass: {
+        auth: {
+          data: {
+            access_token: 'token-123'
+          }
+        }
+      }
+    });
+    globalThis.fetch.mockResolvedValue({ ok: true, json: async () => ({ data: 'test' }) });
+
+    const response = await globalThis.DashboardAPI.fetchWithAuth('/api/oig_cloud/test-endpoint');
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(response.ok).toBe(true);
+  });
+
+  it('handles empty-string POST body without JSON.parse error', async () => {
+    const callApi = vi.fn().mockResolvedValue({ ok: true });
+    setParentQueryResult({
+      hass: {
+        callApi,
+        auth: {
+          data: {}
+        }
+      }
+    });
+
+    await globalThis.DashboardAPI.fetchWithAuth('/api/oig_cloud/test', {
+      method: 'POST',
+      body: ''
+    });
+
+    expect(callApi).toHaveBeenCalledWith('POST', 'oig_cloud/test', undefined);
+  });
+
+  it('returns null when PlannerState fallback receives malformed JSON', async () => {
+    setParentQueryResult({
+      hass: {
+        auth: {
+          data: {
+            access_token: 'token-123'
+          }
+        }
+      }
+    });
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => {
+        throw new Error('Invalid JSON');
+      }
+    });
+
+    const result = await globalThis.PlannerState.fetchSettings(true);
+
+    expect(result).toBeNull();
+  });
+
   it('returns the default hybrid plan label from PlannerState', async () => {
     setParentQueryResult({
       hass: {

--- a/tests/fe/unit/api.test.js
+++ b/tests/fe/unit/api.test.js
@@ -1,0 +1,94 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadScript } from './helpers/load_script.js';
+
+function setParentQueryResult(result) {
+  Object.defineProperty(globalThis, 'parent', {
+    value: {
+      document: {
+        querySelector: () => result
+      }
+    },
+    configurable: true
+  });
+}
+
+describe('Dashboard API auth handling', () => {
+  beforeAll(() => {
+    loadScript('custom_components/oig_cloud/www/js/core/api.js');
+  });
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+    globalThis.INVERTER_SN = '123';
+    setParentQueryResult(null);
+  });
+
+  it('blocks authenticated HA API requests when token is missing', async () => {
+    await expect(
+      globalThis.DashboardAPI.fetchWithAuth('/api/oig_cloud/test-endpoint')
+    ).rejects.toThrow('No Home Assistant access token available');
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('prevents PlannerState fallback from sending unauthenticated requests', async () => {
+    const result = await globalThis.PlannerState.fetchSettings(true);
+
+    expect(result).toBeNull();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('adds bearer token header when HA token is available', async () => {
+    setParentQueryResult({
+      hass: {
+        auth: {
+          data: {
+            access_token: 'token-123'
+          }
+        }
+      }
+    });
+    globalThis.fetch.mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
+
+    await globalThis.DashboardAPI.fetchWithAuth('/api/oig_cloud/test-endpoint', {
+      headers: {
+        'X-Test': '1'
+      }
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/oig_cloud/test-endpoint',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-123',
+          'X-Test': '1'
+        })
+      })
+    );
+  });
+
+  it('uses hass.callApi for HA API requests when raw token is unavailable', async () => {
+    const callApi = vi.fn().mockResolvedValue({ today: [] });
+    setParentQueryResult({
+      hass: {
+        callApi,
+        auth: {
+          data: {}
+        }
+      }
+    });
+
+    const response = await globalThis.DashboardAPI.fetchWithAuth(
+      '/api/oig_cloud/battery_forecast/123/detail_tabs?tab=today&plan=hybrid'
+    );
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(callApi).toHaveBeenCalledWith(
+      'GET',
+      'oig_cloud/battery_forecast/123/detail_tabs?tab=today&plan=hybrid',
+      undefined
+    );
+    await expect(response.json()).resolves.toEqual({ today: [] });
+  });
+});

--- a/tests/test_adaptive_load_profiles_sensor_more.py
+++ b/tests/test_adaptive_load_profiles_sensor_more.py
@@ -273,56 +273,36 @@ def test_get_energy_unit_factor(monkeypatch):
 async def test_load_hourly_series_and_earliest_start(monkeypatch):
     sensor = _make_sensor(monkeypatch)
 
-    class DummyResult:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def fetchall(self):
-            return self._rows
-
-        def scalar(self):
-            return self._rows
-
-    class DummySession:
-        def __init__(self, rows):
-            self._rows = rows
-
-        def execute(self, *_args, **_kwargs):
-            return DummyResult(self._rows)
-
     class DummyRecorder:
-        def __init__(self, rows):
-            self._rows = rows
-
         async def async_add_executor_job(self, func):
             return func()
 
-        def get_session(self):
-            return DummySession(self._rows)
+    def fake_stats(_hass, _start, _end, ids, period, _units, _types):
+        sensor_id = next(iter(ids))
+        if period == "hour":
+            return {
+                sensor_id: [
+                    {
+                        "start": datetime(2025, 1, 1, tzinfo=timezone.utc),
+                        "sum": 1000.0,
+                        "mean": 500.0,
+                        "state": None,
+                    }
+                ]
+            }
+        return {
+            sensor_id: [{"start": datetime(2025, 1, 1, tzinfo=timezone.utc), "sum": 1.0}]
+        }
 
-    def _session_scope(*_args, **_kwargs):
-        session = _kwargs.get("session")
-
-        class _Ctx:
-            def __enter__(self_inner):
-                return session
-
-            def __exit__(self_inner, *_exc):
-                return False
-
-        return _Ctx()
-
-    rows = [(1000.0, 500.0, None, 1000.0)]
     sensor._hass = SimpleNamespace(states=SimpleNamespace(get=lambda _eid: None))
     monkeypatch.setattr(
         "homeassistant.helpers.recorder.get_instance",
-        lambda *_args, **_kwargs: DummyRecorder(rows),
+        lambda *_args, **_kwargs: DummyRecorder(),
     )
     monkeypatch.setattr(
-        "homeassistant.helpers.recorder.session_scope",
-        _session_scope,
+        "homeassistant.components.recorder.statistics.statistics_during_period",
+        fake_stats,
     )
-    monkeypatch.setattr("sqlalchemy.text", lambda _q: _q)
     series = await sensor._load_hourly_series(
         "sensor.test",
         datetime(2025, 1, 1, tzinfo=timezone.utc),
@@ -331,11 +311,6 @@ async def test_load_hourly_series_and_earliest_start(monkeypatch):
     )
     assert series
 
-    min_ts = 1234.0
-    monkeypatch.setattr(
-        "homeassistant.helpers.recorder.get_instance",
-        lambda *_args, **_kwargs: DummyRecorder(min_ts),
-    )
     earliest = await sensor._get_earliest_statistics_start("sensor.test")
     assert earliest is not None
 

--- a/tests/test_adaptive_load_profiles_sensor_more2.py
+++ b/tests/test_adaptive_load_profiles_sensor_more2.py
@@ -559,6 +559,30 @@ def test_parse_hourly_row_tuple_and_state_fallback(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_earliest_statistics_start_accepts_start_time_key(monkeypatch):
+    sensor = _make_sensor(monkeypatch)
+    sensor._hass = SimpleNamespace()
+
+    class DummyRecorder:
+        async def async_add_executor_job(self, func):
+            return func()
+
+    monkeypatch.setattr(
+        "homeassistant.helpers.recorder.get_instance",
+        lambda *_a, **_k: DummyRecorder(),
+    )
+    monkeypatch.setattr(
+        "homeassistant.components.recorder.statistics.statistics_during_period",
+        lambda *_a, **_k: {
+            "sensor.test": [{"start_time": "2025-01-01T00:00:00+00:00", "sum": 1.0}]
+        },
+    )
+
+    earliest = await sensor._get_earliest_statistics_start("sensor.test")
+    assert earliest == datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
 async def test_load_hourly_series_no_recorder(monkeypatch):
     sensor = _make_sensor(monkeypatch)
     sensor._hass = SimpleNamespace(states=SimpleNamespace(get=lambda _eid: None))

--- a/tests/test_adaptive_load_profiles_sensor_more2.py
+++ b/tests/test_adaptive_load_profiles_sensor_more2.py
@@ -275,11 +275,15 @@ async def test_load_hourly_series_empty_rows(monkeypatch):
 
     class DummyRecorder:
         async def async_add_executor_job(self, func):
-            return []
+            return func()
 
     monkeypatch.setattr(
         "homeassistant.helpers.recorder.get_instance",
         lambda *_a, **_k: DummyRecorder(),
+    )
+    monkeypatch.setattr(
+        "homeassistant.components.recorder.statistics.statistics_during_period",
+        lambda *_a, **_k: {},
     )
     series = await sensor._load_hourly_series(
         "sensor.test",
@@ -297,15 +301,25 @@ async def test_load_hourly_series_value_filters(monkeypatch):
 
     class DummyRecorder:
         async def async_add_executor_job(self, func):
-            return [
-                (None, None, None, 1),
-                (None, None, None, 2),
-                (1.0, 2.0, None, 3),
-            ]
+            return func()
 
     monkeypatch.setattr(
         "homeassistant.helpers.recorder.get_instance",
         lambda *_a, **_k: DummyRecorder(),
+    )
+    monkeypatch.setattr(
+        "homeassistant.components.recorder.statistics.statistics_during_period",
+        lambda *_a, **_k: {
+            "sensor.test": [
+                {"start": datetime(2025, 1, 1, 1, tzinfo=timezone.utc)},
+                {"start": datetime(2025, 1, 1, 2, tzinfo=timezone.utc)},
+                {
+                    "start": datetime(2025, 1, 1, 3, tzinfo=timezone.utc),
+                    "sum": 1.0,
+                    "mean": 2.0,
+                },
+            ]
+        },
     )
 
     series = await sensor._load_hourly_series(
@@ -314,7 +328,7 @@ async def test_load_hourly_series_value_filters(monkeypatch):
         datetime(2025, 1, 2, tzinfo=timezone.utc),
         value_field="mean",
     )
-    assert series == [(datetime(1970, 1, 1, 0, 0, 3, tzinfo=timezone.utc), 0.002)]
+    assert series == [(datetime(2025, 1, 1, 3, 0, tzinfo=timezone.utc), 0.002)]
 
     series = await sensor._load_hourly_series(
         "sensor.test",
@@ -322,7 +336,7 @@ async def test_load_hourly_series_value_filters(monkeypatch):
         datetime(2025, 1, 2, tzinfo=timezone.utc),
         value_field="sum",
     )
-    assert series == [(datetime(1970, 1, 1, 0, 0, 3, tzinfo=timezone.utc), 0.001)]
+    assert series == [(datetime(2025, 1, 1, 3, 0, tzinfo=timezone.utc), 0.001)]
 
 
 @pytest.mark.asyncio
@@ -357,11 +371,15 @@ async def test_get_earliest_statistics_start_no_data(monkeypatch):
 
     class DummyRecorder:
         async def async_add_executor_job(self, func):
-            return None
+            return func()
 
     monkeypatch.setattr(
         "homeassistant.helpers.recorder.get_instance",
         lambda *_a, **_k: DummyRecorder(),
+    )
+    monkeypatch.setattr(
+        "homeassistant.components.recorder.statistics.statistics_during_period",
+        lambda *_a, **_k: {},
     )
     assert await sensor._get_earliest_statistics_start("sensor.test") is None
 
@@ -410,17 +428,23 @@ async def test_load_hourly_series_filters_out_of_range(monkeypatch):
 
     class DummyRecorder:
         async def async_add_executor_job(self, func):
-            return [
-                (1.0, None, None, 1),
-                (None, None, None, 2),
-                (-1.0, None, None, 3),
-                (20001.0, None, None, 4),
-                (1.0, None, None, 5),
-            ]
+            return func()
 
     monkeypatch.setattr(
         "homeassistant.helpers.recorder.get_instance",
         lambda *_a, **_k: DummyRecorder(),
+    )
+    monkeypatch.setattr(
+        "homeassistant.components.recorder.statistics.statistics_during_period",
+        lambda *_a, **_k: {
+            "sensor.test": [
+                {"start": datetime(2025, 1, 1, 1, tzinfo=timezone.utc), "sum": 1.0},
+                {"start": datetime(2025, 1, 1, 2, tzinfo=timezone.utc)},
+                {"start": datetime(2025, 1, 1, 3, tzinfo=timezone.utc), "sum": -1.0},
+                {"start": datetime(2025, 1, 1, 4, tzinfo=timezone.utc), "sum": 20001.0},
+                {"start": datetime(2025, 1, 1, 5, tzinfo=timezone.utc), "sum": 1.0},
+            ]
+        },
     )
 
     series = await sensor._load_hourly_series(
@@ -430,8 +454,8 @@ async def test_load_hourly_series_filters_out_of_range(monkeypatch):
         value_field="sum",
     )
     assert series == [
-        (datetime(1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc), 0.001),
-        (datetime(1970, 1, 1, 0, 0, 5, tzinfo=timezone.utc), 0.001),
+        (datetime(2025, 1, 1, 1, 0, tzinfo=timezone.utc), 0.001),
+        (datetime(2025, 1, 1, 5, 0, tzinfo=timezone.utc), 0.001),
     ]
 
 
@@ -520,42 +544,18 @@ async def test_load_hourly_series_invalid_rows(monkeypatch):
     sensor = _make_sensor(monkeypatch)
     sensor._hass = SimpleNamespace(states=SimpleNamespace(get=lambda _eid: None))
 
-    class DummyResult:
-        def fetchall(self):
-            return [(None, None, None, "bad")]
-
-    class DummySession:
-        def execute(self, *_args, **_kwargs):
-            return DummyResult()
-
     class DummyRecorder:
         async def async_add_executor_job(self, func):
             return func()
-
-        def get_session(self):
-            return DummySession()
-
-    def _session_scope(*_args, **_kwargs):
-        session = _kwargs.get("session")
-
-        class _Ctx:
-            def __enter__(self_inner):
-                return session
-
-            def __exit__(self_inner, *_exc):
-                return False
-
-        return _Ctx()
 
     monkeypatch.setattr(
         "homeassistant.helpers.recorder.get_instance",
         lambda *_a, **_k: DummyRecorder(),
     )
     monkeypatch.setattr(
-        "homeassistant.helpers.recorder.session_scope",
-        _session_scope,
+        "homeassistant.components.recorder.statistics.statistics_during_period",
+        lambda *_a, **_k: {"sensor.test": [{"start": "bad", "sum": 1.0}]},
     )
-    monkeypatch.setattr("sqlalchemy.text", lambda _q: _q)
     series = await sensor._load_hourly_series(
         "sensor.test",
         datetime(2025, 1, 1, tzinfo=timezone.utc),

--- a/tests/test_adaptive_load_profiles_sensor_more2.py
+++ b/tests/test_adaptive_load_profiles_sensor_more2.py
@@ -459,6 +459,31 @@ async def test_load_hourly_series_filters_out_of_range(monkeypatch):
     ]
 
 
+def test_build_current_match_at_midnight_current_hour_zero(monkeypatch):
+    """Cover _build_current_match at exactly midnight (current_hour == 0)."""
+    sensor = _make_sensor(monkeypatch)
+
+    # Set now to exactly midnight (hour 0)
+    now = datetime(2025, 1, 2, 0, 5, tzinfo=timezone.utc)
+    monkeypatch.setattr(module.dt_util, "now", lambda: now)
+
+    yesterday = now.date() - timedelta(days=1)
+    series = [
+        (
+            datetime.combine(yesterday, datetime.min.time(), tzinfo=timezone.utc)
+            + timedelta(hours=i),
+            1.0,
+        )
+        for i in range(24)
+    ]
+    hour_medians = {i: 1.0 for i in range(24)}
+
+    # At midnight, should return match with only yesterday's data
+    result = sensor._build_current_match(series, hour_medians)
+    assert result is not None
+    assert len(result) == 24  # Only yesterday's 24 hours
+
+
 def test_build_current_match_missing_today_values(monkeypatch):
     sensor = _make_sensor(monkeypatch)
 

--- a/tests/test_adaptive_load_profiles_sensor_more2.py
+++ b/tests/test_adaptive_load_profiles_sensor_more2.py
@@ -523,6 +523,41 @@ def test_build_current_match_empty_today_values(monkeypatch):
     assert sensor._build_current_match(series, {}) is None
 
 
+def test_coerce_stat_timestamp_variants(monkeypatch):
+    sensor = _make_sensor(monkeypatch)
+
+    naive = datetime(2025, 1, 1, 12, 0)
+    coerced_naive = sensor._coerce_stat_timestamp(naive)
+    assert coerced_naive is not None
+    assert coerced_naive.tzinfo is not None
+
+    coerced_iso = sensor._coerce_stat_timestamp("2025-01-01T12:00:00+00:00")
+    assert coerced_iso == datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    coerced_ms = sensor._coerce_stat_timestamp(1735732800000)
+    assert coerced_ms == datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    assert sensor._coerce_stat_timestamp("not-a-date") is None
+
+
+def test_parse_hourly_row_tuple_and_state_fallback(monkeypatch):
+    sensor = _make_sensor(monkeypatch)
+
+    tuple_row = (None, None, 4.0, 1735732800)
+    parsed_tuple = sensor._parse_hourly_row(tuple_row, "sum", 0.001)
+    assert parsed_tuple == (
+        datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc),
+        0.004,
+    )
+
+    dict_row = {"start_time": "2025-01-01T13:00:00+00:00", "state": 5.0}
+    parsed_dict = sensor._parse_hourly_row(dict_row, "sum", 0.001)
+    assert parsed_dict == (
+        datetime(2025, 1, 1, 13, 0, tzinfo=timezone.utc),
+        0.005,
+    )
+
+
 @pytest.mark.asyncio
 async def test_load_hourly_series_no_recorder(monkeypatch):
     sensor = _make_sensor(monkeypatch)

--- a/tests/test_battery_efficiency_sensor.py
+++ b/tests/test_battery_efficiency_sensor.py
@@ -583,6 +583,32 @@ async def test_fallback_to_statistics_fills_missing_battery_bounds(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fallback_to_statistics_keeps_complete_values_without_lookup(monkeypatch):
+    called = {"count": 0}
+
+    async def fake_stats(*_a, **_k):
+        called["count"] += 1
+        return None
+
+    monkeypatch.setattr(eff_module, "_load_month_metrics_from_statistics", fake_stats)
+
+    out = await eff_module._fallback_to_statistics(
+        DummyHass(),
+        dt_util.utcnow(),
+        dt_util.utcnow(),
+        "sensor.charge",
+        "sensor.discharge",
+        "sensor.batt",
+        12000.0,
+        9000.0,
+        5.0,
+        6.0,
+    )
+    assert out == (12000.0, 9000.0, 5.0, 6.0)
+    assert called["count"] == 0
+
+
+@pytest.mark.asyncio
 async def test_load_month_metrics_history_wrapper_compat_kwargs(monkeypatch):
     hass = DummyHass()
     captured = {}
@@ -727,3 +753,21 @@ async def test_load_month_metrics_from_statistics_missing_meta_for_battery(monke
     assert result is not None
     assert result["battery_start_kwh"] is None
     assert result["battery_end_kwh"] is None
+
+
+@pytest.mark.asyncio
+async def test_load_month_metrics_from_statistics_no_recorder_instance(monkeypatch):
+    monkeypatch.setattr(
+        "homeassistant.helpers.recorder.get_instance",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = await eff_module._load_month_metrics_from_statistics(
+        DummyHass(),
+        dt_util.utcnow(),
+        dt_util.utcnow(),
+        "sensor.c",
+        "sensor.d",
+        "sensor.b",
+    )
+    assert result is None

--- a/tests/test_battery_efficiency_sensor.py
+++ b/tests/test_battery_efficiency_sensor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -557,6 +556,33 @@ async def test_fallback_to_statistics_fills_missing_values(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fallback_to_statistics_fills_missing_battery_bounds(monkeypatch):
+    async def fake_stats(*_a, **_k):
+        return {
+            "charge_wh": 12000.0,
+            "discharge_wh": 9000.0,
+            "battery_start_kwh": 5.0,
+            "battery_end_kwh": 6.0,
+        }
+
+    monkeypatch.setattr(eff_module, "_load_month_metrics_from_statistics", fake_stats)
+
+    out = await eff_module._fallback_to_statistics(
+        DummyHass(),
+        dt_util.utcnow(),
+        dt_util.utcnow(),
+        "sensor.charge",
+        "sensor.discharge",
+        "sensor.batt",
+        12000.0,
+        9000.0,
+        None,
+        None,
+    )
+    assert out == (12000.0, 9000.0, 5.0, 6.0)
+
+
+@pytest.mark.asyncio
 async def test_load_month_metrics_history_wrapper_compat_kwargs(monkeypatch):
     hass = DummyHass()
     captured = {}
@@ -612,7 +638,7 @@ async def test_load_month_metrics_from_statistics_import_error(monkeypatch):
     orig_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "homeassistant.components.recorder.db_schema":
+        if name == "homeassistant.components.recorder.statistics":
             raise ImportError("boom")
         return orig_import(name, *args, **kwargs)
 
@@ -631,81 +657,27 @@ async def test_load_month_metrics_from_statistics_import_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_load_month_metrics_from_statistics_query_success(monkeypatch):
-    class Col:
-        def in_(self, _v):
-            return self
+    class DummyRecorder:
+        async def async_add_executor_job(self, func, *args):
+            return func(*args)
 
-        def __eq__(self, _v):
-            return True
-
-        def __ge__(self, _v):
-            return self
-
-        def __lt__(self, _v):
-            return self
-
-        def desc(self):
-            return self
-
-        def asc(self):
-            return self
-
-    class FakeStatisticsMeta:
-        statistic_id = Col()
-        id = Col()
-
-    class FakeStatistics:
-        metadata_id = Col()
-        start_ts = Col()
-
-    class Query:
-        def __init__(self, kind):
-            self.kind = kind
-            self._meta_id = None
-
-        def filter(self, *args):
-            if self.kind == "stats" and args:
-                self._meta_id = 1
-            return self
-
-        def order_by(self, _arg):
-            return self
-
-        def all(self):
-            return [
-                ("sensor.c", 1),
-                ("sensor.d", 2),
-                ("sensor.b", 3),
-            ]
-
-        def first(self):
-            if self._meta_id == 1:
-                return SimpleNamespace(sum=12000.0)
-            if self._meta_id == 2:
-                return SimpleNamespace(sum=9000.0)
-            return SimpleNamespace(state=5.5)
-
-    class Session:
-        def query(self, *args):
-            if len(args) == 2:
-                return Query("meta")
-            return Query("stats")
-
-    @contextmanager
-    def fake_session_scope(**_kwargs):
-        yield Session()
+    def fake_stats(_hass, _start, _end, _ids, _period, _units, _types):
+        return {
+            "sensor.c": [{"start": dt_util.utcnow(), "sum": 12000.0}],
+            "sensor.d": [{"start": dt_util.utcnow(), "sum": 9000.0}],
+            "sensor.b": [
+                {"start": dt_util.utcnow(), "state": 5.5},
+                {"start": dt_util.utcnow(), "state": 6.0},
+            ],
+        }
 
     monkeypatch.setattr(
-        "homeassistant.components.recorder.db_schema.Statistics",
-        FakeStatistics,
+        "homeassistant.helpers.recorder.get_instance",
+        lambda *_args, **_kwargs: DummyRecorder(),
     )
     monkeypatch.setattr(
-        "homeassistant.components.recorder.db_schema.StatisticsMeta",
-        FakeStatisticsMeta,
-    )
-    monkeypatch.setattr(
-        "homeassistant.components.recorder.util.session_scope",
-        fake_session_scope,
+        "homeassistant.components.recorder.statistics.statistics_during_period",
+        fake_stats,
     )
 
     result = await eff_module._load_month_metrics_from_statistics(
@@ -718,78 +690,30 @@ async def test_load_month_metrics_from_statistics_query_success(monkeypatch):
     )
     assert result is not None
     assert result["charge_wh"] == 12000.0
-    assert result["discharge_wh"] == 12000.0
+    assert result["discharge_wh"] == 9000.0
+    assert result["battery_start_kwh"] == 5.5
+    assert result["battery_end_kwh"] == 6.0
 
 
 @pytest.mark.asyncio
 async def test_load_month_metrics_from_statistics_missing_meta_for_battery(monkeypatch):
-    class Col:
-        def in_(self, _v):
-            return self
+    class DummyRecorder:
+        async def async_add_executor_job(self, func, *args):
+            return func(*args)
 
-        def __eq__(self, _v):
-            return True
-
-        def __ge__(self, _v):
-            return self
-
-        def __lt__(self, _v):
-            return self
-
-        def desc(self):
-            return self
-
-        def asc(self):
-            return self
-
-    class FakeStatisticsMeta:
-        statistic_id = Col()
-        id = Col()
-
-    class FakeStatistics:
-        metadata_id = Col()
-        start_ts = Col()
-
-    class Query:
-        def __init__(self, kind):
-            self.kind = kind
-
-        def filter(self, *_args):
-            return self
-
-        def order_by(self, _arg):
-            return self
-
-        def all(self):
-            return [
-                ("sensor.c", 1),
-                ("sensor.d", 2),
-            ]
-
-        def first(self):
-            return SimpleNamespace(sum=5000.0)
-
-    class Session:
-        def query(self, *args):
-            if len(args) == 2:
-                return Query("meta")
-            return Query("stats")
-
-    @contextmanager
-    def fake_session_scope(**_kwargs):
-        yield Session()
+    def fake_stats(_hass, _start, _end, _ids, _period, _units, _types):
+        return {
+            "sensor.c": [{"start": dt_util.utcnow(), "sum": 5000.0}],
+            "sensor.d": [{"start": dt_util.utcnow(), "sum": 4000.0}],
+        }
 
     monkeypatch.setattr(
-        "homeassistant.components.recorder.db_schema.Statistics",
-        FakeStatistics,
+        "homeassistant.helpers.recorder.get_instance",
+        lambda *_args, **_kwargs: DummyRecorder(),
     )
     monkeypatch.setattr(
-        "homeassistant.components.recorder.db_schema.StatisticsMeta",
-        FakeStatisticsMeta,
-    )
-    monkeypatch.setattr(
-        "homeassistant.components.recorder.util.session_scope",
-        fake_session_scope,
+        "homeassistant.components.recorder.statistics.statistics_during_period",
+        fake_stats,
     )
 
     result = await eff_module._load_month_metrics_from_statistics(

--- a/tests/test_battery_efficiency_sensor.py
+++ b/tests/test_battery_efficiency_sensor.py
@@ -519,6 +519,78 @@ def test_compute_metrics_invalid_values():
     assert metrics["efficiency_pct"] == 100.0
 
 
+def test_stat_value_with_object_and_getattr(monkeypatch):
+    """Cover _stat_value with object (not dict) and getattr path."""
+    # Test with object having sum attribute (prefer_sum=True)
+    class StatItem:
+        def __init__(self, sum_val, state_val):
+            self.sum = sum_val
+            self.state = state_val
+
+    item = StatItem(1000.0, 500.0)
+    result = eff_module._stat_value(item, prefer_sum=True)
+    assert result == 1000.0
+
+    # Test with object missing sum but having state (prefer_sum=True)
+    item2 = StatItem(None, 750.0)
+    result2 = eff_module._stat_value(item2, prefer_sum=True)
+    assert result2 == 750.0
+
+    # Test prefer_sum=False path with state key
+    item3 = StatItem(1000.0, 600.0)
+    result3 = eff_module._stat_value(item3, prefer_sum=False)
+    assert result3 == 600.0
+
+    # Test with dict and prefer_sum=False
+    dict_item = {"state": 800.0, "mean": 700.0}
+    result4 = eff_module._stat_value(dict_item, prefer_sum=False)
+    assert result4 == 800.0
+
+    # Test with invalid value that can't be converted to float
+    class BadItem:
+        def __init__(self):
+            self.state = "not-a-number"
+
+    bad = BadItem()
+    result5 = eff_module._stat_value(bad, prefer_sum=False)
+    assert result5 is None
+
+
+def test_reset_last_month_metrics_clears_on_different_key(monkeypatch):
+    """Cover _reset_last_month_metrics clearing when key is different."""
+    hass = DummyHass()
+    sensor = _make_sensor(monkeypatch, hass)
+    # Set up existing metrics for a different month
+    sensor._last_month_key = "2026-01"
+    sensor._last_month_metrics = {"efficiency_pct": 80.0}
+
+    # Call with a different key - should clear
+    different_key = "2026-02"
+    sensor._reset_last_month_metrics(different_key)
+    assert sensor._last_month_metrics is None
+    assert sensor._last_month_key is None
+
+
+def test_rollover_month_clears_matching_snapshot(monkeypatch):
+    """Cover _rollover_month clearing snapshot when month_key matches."""
+    hass = DummyHass()
+    sensor = _make_sensor(monkeypatch, hass)
+
+    # Set up a snapshot for the previous month
+    prev_key = "2026-01"
+    sensor._month_snapshot = {"month_key": prev_key, "charge_wh": 10000}
+    sensor._current_month_key = "2026-01"
+
+    # Call on day 1 with matching snapshot
+    now_local = datetime(2026, 2, 1, 0, 10, tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    sensor._rollover_month(now_local, prev_key)
+
+    # Snapshot should be cleared
+    assert sensor._month_snapshot is None
+    # Current month key should be updated
+    assert sensor._current_month_key == "2026-02"
+
+
 def test_previous_month_and_range():
     year, month = eff_module._previous_month(datetime(2026, 1, 15, tzinfo=timezone.utc))
     assert (year, month) == (2025, 12)

--- a/tests/test_charging_plan_more.py
+++ b/tests/test_charging_plan_more.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Any
 
 import pytest
 
@@ -8,6 +9,7 @@ from custom_components.oig_cloud.battery_forecast.planning import charging_plan
 from custom_components.oig_cloud.battery_forecast.planning.charging_plan import (
     EconomicChargingPlanConfig,
 )
+from custom_components.oig_cloud.battery_forecast.planning.rollout_flags import RolloutFlags
 
 
 def _timeline_point(ts: str, battery: float, price: float = 2.0):
@@ -21,7 +23,7 @@ def _timeline_point(ts: str, battery: float, price: float = 2.0):
 
 
 def _make_plan(**overrides) -> EconomicChargingPlanConfig:
-    base = dict(
+    base: dict[str, Any] = dict(
         min_capacity_kwh=1.0,
         min_capacity_floor=0.5,
         effective_minimum_kwh=1.0,
@@ -154,3 +156,373 @@ def test_smart_charging_plan_critical_fix(monkeypatch):
 
     assert "target_capacity_kwh" in metrics
     assert any(point["grid_charge_kwh"] > 0 for point in result_timeline)
+
+
+def test_should_pre_charge_for_peak_avoidance_waits_for_cheaper_post_peak_slot():
+    intervals = [
+        {
+            "timestamp": "2025-01-01T04:00:00+00:00",
+            "spot_price_czk": 1.8,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T05:00:00+00:00",
+            "spot_price_czk": 2.0,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T06:00:00+00:00",
+            "spot_price_czk": 4.5,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T07:00:00+00:00",
+            "spot_price_czk": 4.7,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T08:00:00+00:00",
+            "spot_price_czk": 1.0,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+    ]
+
+    decision = charging_plan.should_pre_charge_for_peak_avoidance(
+        config=_make_plan(hw_min_soc_kwh=1.5, round_trip_efficiency=0.87, max_capacity=2.0),
+        flags=RolloutFlags(enable_pre_peak_charging=True),
+        intervals=intervals,
+        current_hour=3,
+        current_soc_kwh=1.6,
+    )
+
+    assert decision.should_charge is False
+    assert decision.reason == "cheaper_post_peak_available"
+
+
+def test_should_pre_charge_for_peak_avoidance_preserves_headroom_for_future_negative_price():
+    intervals = [
+        {
+            "timestamp": "2025-01-01T04:00:00+00:00",
+            "spot_price_czk": 1.8,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T05:00:00+00:00",
+            "spot_price_czk": 1.9,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T06:00:00+00:00",
+            "spot_price_czk": 4.5,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T07:00:00+00:00",
+            "spot_price_czk": 4.7,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T08:00:00+00:00",
+            "spot_price_czk": -0.5,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.8,
+        },
+    ]
+
+    decision = charging_plan.should_pre_charge_for_peak_avoidance(
+        config=_make_plan(
+            hw_min_soc_kwh=1.5,
+            round_trip_efficiency=0.87,
+            max_capacity=2.4,
+        ),
+        flags=RolloutFlags(enable_pre_peak_charging=True),
+        intervals=intervals,
+        current_hour=3,
+        current_soc_kwh=1.6,
+    )
+
+    assert decision.should_charge is False
+    assert decision.reason == "future_negative_price_headroom"
+
+
+def test_should_pre_charge_for_peak_avoidance_keeps_precharge_when_pre_peak_load_would_drain_battery():
+    intervals = [
+        {
+            "timestamp": "2025-01-01T04:00:00+00:00",
+            "spot_price_czk": 1.8,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.5,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T05:00:00+00:00",
+            "spot_price_czk": 1.9,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.5,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T06:00:00+00:00",
+            "spot_price_czk": 4.5,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.1,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T07:00:00+00:00",
+            "spot_price_czk": 4.7,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.1,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T08:00:00+00:00",
+            "spot_price_czk": 1.0,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+    ]
+
+    decision = charging_plan.should_pre_charge_for_peak_avoidance(
+        config=_make_plan(hw_min_soc_kwh=1.5, round_trip_efficiency=0.87),
+        flags=RolloutFlags(enable_pre_peak_charging=True),
+        intervals=intervals,
+        current_hour=3,
+        current_soc_kwh=1.6,
+    )
+
+    assert decision.should_charge is True
+    assert decision.reason == "economical_pre_peak"
+
+
+def test_should_pre_charge_for_peak_avoidance_projects_soc_before_soc_sufficient_check():
+    intervals = [
+        {
+            "timestamp": "2025-01-01T04:00:00+00:00",
+            "spot_price_czk": 1.8,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.2,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T05:00:00+00:00",
+            "spot_price_czk": 1.9,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.2,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T06:00:00+00:00",
+            "spot_price_czk": 4.5,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.1,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T07:00:00+00:00",
+            "spot_price_czk": 4.7,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.1,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T08:00:00+00:00",
+            "spot_price_czk": 4.0,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+    ]
+
+    decision = charging_plan.should_pre_charge_for_peak_avoidance(
+        config=_make_plan(hw_min_soc_kwh=1.0, round_trip_efficiency=0.87),
+        flags=RolloutFlags(enable_pre_peak_charging=True),
+        intervals=intervals,
+        current_hour=3,
+        current_soc_kwh=1.15,
+    )
+
+    assert decision.should_charge is True
+    assert decision.reason == "economical_pre_peak"
+
+
+def test_should_pre_charge_for_peak_avoidance_detects_next_day_cheaper_slot():
+    intervals = [
+        {
+            "timestamp": "2025-01-01T04:00:00+00:00",
+            "spot_price_czk": 2.0,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T05:00:00+00:00",
+            "spot_price_czk": 2.2,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T06:00:00+00:00",
+            "spot_price_czk": 4.8,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T07:00:00+00:00",
+            "spot_price_czk": 4.9,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-02T04:00:00+00:00",
+            "spot_price_czk": 0.7,
+            "battery_capacity_kwh": 1.6,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+    ]
+
+    decision = charging_plan.should_pre_charge_for_peak_avoidance(
+        config=_make_plan(hw_min_soc_kwh=1.5, round_trip_efficiency=0.87),
+        flags=RolloutFlags(enable_pre_peak_charging=True),
+        intervals=intervals,
+        current_hour=3,
+        current_soc_kwh=1.6,
+    )
+
+    assert decision.should_charge is False
+    assert decision.reason == "cheaper_post_peak_available"
+
+
+def test_should_pre_charge_for_peak_avoidance_ignores_negative_price_when_headroom_remains_sufficient():
+    intervals = [
+        {
+            "timestamp": "2025-01-01T04:00:00+00:00",
+            "spot_price_czk": 1.8,
+            "battery_capacity_kwh": 1.0,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T05:00:00+00:00",
+            "spot_price_czk": 1.9,
+            "battery_capacity_kwh": 1.0,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T06:00:00+00:00",
+            "spot_price_czk": 4.5,
+            "battery_capacity_kwh": 1.0,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T07:00:00+00:00",
+            "spot_price_czk": 4.7,
+            "battery_capacity_kwh": 1.0,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.0,
+        },
+        {
+            "timestamp": "2025-01-01T08:00:00+00:00",
+            "spot_price_czk": 2.2,
+            "battery_capacity_kwh": 1.0,
+            "grid_charge_kwh": 0.0,
+            "reason": "normal",
+            "consumption_kwh": 0.0,
+            "solar_production_kwh": 0.6,
+        },
+    ]
+
+    decision = charging_plan.should_pre_charge_for_peak_avoidance(
+        config=_make_plan(hw_min_soc_kwh=1.0, round_trip_efficiency=0.87, max_capacity=10.0),
+        flags=RolloutFlags(enable_pre_peak_charging=True),
+        intervals=intervals,
+        current_hour=3,
+        current_soc_kwh=1.0,
+    )
+
+    assert decision.should_charge is True
+    assert decision.reason == "economical_pre_peak"

--- a/tests/test_regression_peak_cluster.py
+++ b/tests/test_regression_peak_cluster.py
@@ -132,7 +132,11 @@ def test_pv_first_defers_pre_peak_when_solar_available(freeze_planner_now: None)
 
 
 def test_pre_peak_does_not_interfere_with_pv_first_decision(freeze_planner_now: None):
-    timeline = _make_pre_peak_intervals(initial_soc_kwh=2.1, solar_kwh_pre_peak=0.0)
+    timeline = _make_pre_peak_intervals(
+        initial_soc_kwh=2.1,
+        solar_kwh_pre_peak=0.0,
+        pre_peak_price=3.0,
+    )
     plan = _make_config(pv_forecast_kwh=2.5, pv_forecast_confidence=0.9)
     flags = RolloutFlags(enable_pre_peak_charging=True, pv_first_policy_enabled=True)
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,9 +4,11 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     include: ['tests/fe/unit/**/*.test.js'],
-    exclude: ['tests/fe/specs/**', 'tests/e2e/**']
-  },
-  coverage: {
-    provider: 'v8'
+    exclude: ['tests/fe/specs/**', 'tests/e2e/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage'
+    }
   }
 });


### PR DESCRIPTION
## Summary
- harden legacy V1 dashboard API auth so embedded HA dashboards use `hass.callApi` when available and stop sending unauthenticated `/api/oig_cloud/...` fallback requests
- move adaptive profile and battery efficiency statistics lookups onto Home Assistant recorder/statistics helper APIs via the recorder executor
- bump the integration version to 2.3.16 and document the hotfix in the changelog

## Validation
- npm run test:fe:unit -- tests/fe/unit/api.test.js
- npm run lint:js
- .venv/bin/pytest tests/test_battery_efficiency_sensor.py tests/test_adaptive_load_profiles_sensor_more.py tests/test_adaptive_load_profiles_sensor_more2.py