### PR TITLE
fix: preserve planner headroom before low-value solar surplus

### DIFF
--- a/custom_components/oig_cloud/battery_forecast/strategy/hybrid.py
+++ b/custom_components/oig_cloud/battery_forecast/strategy/hybrid.py
@@ -209,6 +209,7 @@ class HybridStrategy:
             prices=prices,
             solar_forecast=solar_forecast,
             consumption_forecast=consumption_forecast,
+            export_prices=exports,
             balancing_plan=balancing_plan,
             negative_price_intervals=negative_prices,
         )
@@ -469,6 +470,7 @@ class HybridStrategy:
         prices: List[float],
         solar_forecast: List[float],
         consumption_forecast: List[float],
+        export_prices: List[float],
         balancing_plan: Optional[StrategyBalancingPlan] = None,
         negative_price_intervals: Optional[List[int]] = None,
     ) -> Tuple[set[int], Optional[str], set[int]]:
@@ -479,6 +481,7 @@ class HybridStrategy:
             prices=prices,
             solar_forecast=solar_forecast,
             consumption_forecast=consumption_forecast,
+            export_prices=export_prices,
             balancing_plan=balancing_plan,
             negative_price_intervals=negative_price_intervals,
         )

--- a/custom_components/oig_cloud/battery_forecast/strategy/hybrid_planning.py
+++ b/custom_components/oig_cloud/battery_forecast/strategy/hybrid_planning.py
@@ -12,6 +12,10 @@ from .balancing import StrategyBalancingPlan
 
 _LOGGER = logging.getLogger(__name__)
 
+_SOLAR_HEADROOM_ACTIVITY_KWH = 0.05
+_SOLAR_HEADROOM_MIN_SURPLUS_KWH = 0.5
+_SOLAR_HEADROOM_WINDOW_INTERVALS = 48
+
 
 def plan_charging_intervals(
     strategy,
@@ -20,6 +24,7 @@ def plan_charging_intervals(
     prices: List[float],
     solar_forecast: List[float],
     consumption_forecast: List[float],
+    export_prices: Optional[List[float]] = None,
     balancing_plan: Optional[StrategyBalancingPlan] = None,
     negative_price_intervals: Optional[List[int]] = None,
 ) -> Tuple[set[int], Optional[str], set[int]]:
@@ -83,6 +88,15 @@ def plan_charging_intervals(
         target_price_cap = float("inf")
         target_kwh = strategy._max
         target_limit = min(balancing_plan.holding_intervals)
+    else:
+        target_kwh = _resolve_target_soc_goal(
+            strategy,
+            initial_battery_kwh=initial_battery_kwh,
+            solar_forecast=solar_forecast,
+            consumption_forecast=consumption_forecast,
+            export_prices=export_prices,
+            eps_kwh=eps_kwh,
+        )
     _reach_target_soc(
         strategy,
         initial_battery_kwh=initial_battery_kwh,
@@ -107,15 +121,17 @@ def plan_charging_intervals(
             charging_intervals=set(),
         )
         _pre_economic_max_soc = (
-            max(_pre_economic_trajectory) if _pre_economic_trajectory else initial_battery_kwh
+            max([initial_battery_kwh, *_pre_economic_trajectory])
+            if _pre_economic_trajectory
+            else initial_battery_kwh
         )
-        _target_effective = strategy._target if getattr(strategy, "_target", None) is not None else 0.0
+        _target_effective = target_kwh if target_kwh is not None else 0.0
         if _pre_economic_max_soc >= _target_effective - eps_kwh:
             _LOGGER.debug(
                 "Skipping economic charging: solar+plan reaches target SOC "
                 "(max_soc=%.3f >= target=%.3f)",
                 _pre_economic_max_soc,
-                strategy._target,
+                _target_effective,
             )
         else:
             _apply_economic_charging(
@@ -179,6 +195,81 @@ def plan_charging_intervals(
     )
 
     return charging_intervals, infeasible_reason, price_band_intervals
+
+
+def _resolve_target_soc_goal(
+    strategy,
+    *,
+    initial_battery_kwh: float,
+    solar_forecast: List[float],
+    consumption_forecast: List[float],
+    export_prices: Optional[List[float]],
+    eps_kwh: float,
+) -> float:
+    target = getattr(strategy, "_target", initial_battery_kwh)
+    planning_min = getattr(strategy, "_planning_min", 0.0)
+    if target <= planning_min + eps_kwh:
+        return target
+
+    preserved_headroom_kwh = _estimate_poor_export_solar_surplus(
+        strategy,
+        solar_forecast=solar_forecast,
+        consumption_forecast=consumption_forecast,
+        export_prices=export_prices,
+    )
+    if preserved_headroom_kwh < _SOLAR_HEADROOM_MIN_SURPLUS_KWH:
+        return target
+
+    max_softening = max(0.0, target - planning_min)
+    effective_target = max(
+        planning_min,
+        target - min(max_softening, preserved_headroom_kwh),
+    )
+    if effective_target < target - eps_kwh:
+        _LOGGER.debug(
+            "Softening target SOC from %.3f to %.3f to preserve %.3f kWh headroom for low-value solar surplus",
+            target,
+            effective_target,
+            target - effective_target,
+        )
+    return effective_target
+
+
+def _estimate_poor_export_solar_surplus(
+    strategy,
+    *,
+    solar_forecast: List[float],
+    consumption_forecast: List[float],
+    export_prices: Optional[List[float]],
+) -> float:
+    if not solar_forecast or not export_prices:
+        return 0.0
+
+    try:
+        export_threshold = max(
+            0.0,
+            float(getattr(strategy.config, "min_export_price_czk", 0.0) or 0.0),
+        )
+    except (TypeError, ValueError):
+        export_threshold = 0.0
+
+    surplus_kwh = 0.0
+    limit = min(
+        len(solar_forecast),
+        len(export_prices),
+        _SOLAR_HEADROOM_WINDOW_INTERVALS,
+    )
+    for idx in range(limit):
+        solar_kwh = solar_forecast[idx] if idx < len(solar_forecast) else 0.0
+        if solar_kwh <= _SOLAR_HEADROOM_ACTIVITY_KWH:
+            continue
+        export_price = export_prices[idx]
+        if export_price > export_threshold:
+            continue
+        load_kwh = consumption_forecast[idx] if idx < len(consumption_forecast) else 0.125
+        surplus_kwh += max(0.0, solar_kwh - load_kwh)
+
+    return surplus_kwh
 
 
 def _build_add_ups_interval(
@@ -546,7 +637,7 @@ def _reach_target_soc(
         if limit_idx <= 0:
             return
         max_soc = (
-            max(battery_trajectory[:limit_idx])
+            max([initial_battery_kwh, *battery_trajectory[:limit_idx]])
             if battery_trajectory
             else initial_battery_kwh
         )

--- a/custom_components/oig_cloud/battery_forecast/strategy/hybrid_scoring.py
+++ b/custom_components/oig_cloud/battery_forecast/strategy/hybrid_scoring.py
@@ -268,12 +268,19 @@ def handle_negative_price(
     export_price: float,
 ) -> Tuple[int, str]:
     """Handle negative price intervals."""
-    _ = load
+    eps_kwh = 0.01
     _ = price
     _ = export_price
     strategy_mode = strategy.config.negative_price_strategy
+    target_kwh = getattr(strategy, "_target", None)
+    max_capacity_kwh = getattr(strategy, "_max", None)
+
+    battery_at_target = target_kwh is not None and battery >= target_kwh - eps_kwh
+    battery_full = max_capacity_kwh is not None and battery >= max_capacity_kwh - eps_kwh
 
     if strategy_mode == NegativePriceStrategy.CHARGE_GRID:
+        if battery_at_target or battery_full:
+            return CBB_MODE_HOME_I, "negative_price_consume"
         return CBB_MODE_HOME_UPS, "negative_price_charge"
     # CURTAIL and CONSUME both use HOME_I for economic reasons
     return CBB_MODE_HOME_I, "negative_price_consume"

--- a/tests/test_hybrid_economic_charging_solar_overflow.py
+++ b/tests/test_hybrid_economic_charging_solar_overflow.py
@@ -52,6 +52,7 @@ class DummyConfig:
     negative_price_strategy = NegativePriceStrategy.CHARGE_GRID
     round_trip_efficiency = 0.9
     price_hysteresis_czk = 0.0
+    min_export_price_czk = -0.5
 
 
 class DummySimConfig:
@@ -68,6 +69,7 @@ class DummyStrategy:
         self.simulator = DummySimulator()
         self._planning_min = 2.0
         self._target = 3.0
+        self._max = 5.0
 
 
 def test_economic_charging_skipped_when_solar_reaches_target():
@@ -99,4 +101,46 @@ def test_economic_charging_skipped_when_solar_reaches_target():
         f"After 1st interval: {initial_battery_kwh + solar_forecast[0] - consumption_forecast[0]}kWh "
         f"(exceeds target {strategy._target}kWh). "
         f"Economic charging should NOT add intervals when solar is sufficient."
+    )
+
+
+def test_target_fill_preserves_headroom_when_future_surplus_has_zero_export_value():
+    strategy = DummyStrategy()
+    strategy._target = 5.0
+
+    charging_intervals, _, _ = module.plan_charging_intervals(
+        strategy,
+        initial_battery_kwh=3.2,
+        solar_forecast=[0.0] * 4 + [0.35] * 8,
+        consumption_forecast=[0.15] * 12,
+        export_prices=[0.0] * 12,
+        prices=[0.6] * 12,
+        balancing_plan=None,
+        negative_price_intervals=None,
+    )
+
+    assert charging_intervals == set(), (
+        "Planner should preserve battery headroom for upcoming low-value solar surplus "
+        "instead of topping battery to 100% before solar ramp-up."
+    )
+
+
+def test_target_fill_still_charges_when_future_surplus_can_be_exported_profitably():
+    strategy = DummyStrategy()
+    strategy._target = 5.0
+
+    charging_intervals, _, _ = module.plan_charging_intervals(
+        strategy,
+        initial_battery_kwh=3.2,
+        solar_forecast=[0.0] * 4 + [0.35] * 8,
+        consumption_forecast=[0.15] * 12,
+        export_prices=[0.6] * 12,
+        prices=[0.6] * 12,
+        balancing_plan=None,
+        negative_price_intervals=None,
+    )
+
+    assert charging_intervals, (
+        "When export remains economically viable, planner may still top up to target "
+        "instead of preserving daytime headroom."
     )

--- a/tests/test_hybrid_scoring_helpers.py
+++ b/tests/test_hybrid_scoring_helpers.py
@@ -78,6 +78,23 @@ def test_handle_negative_price_variants():
     assert reason == "negative_price_consume"
 
 
+def test_handle_negative_price_charge_grid_skips_ups_when_battery_at_target():
+    strategy = DummyStrategy()
+    strategy.config.negative_price_strategy = NegativePriceStrategy.CHARGE_GRID
+
+    mode, reason = module.handle_negative_price(
+        strategy,
+        battery=strategy._target,
+        solar=1.2,
+        load=0.1,
+        price=-1,
+        export_price=0,
+    )
+
+    assert mode == CBB_MODE_HOME_I
+    assert reason == "negative_price_consume"
+
+
 def test_apply_smoothing_merges_short_runs():
     strategy = DummyStrategy()
     decisions = [


### PR DESCRIPTION
## Summary
- preserve effective battery headroom when upcoming solar surplus would otherwise be exported at zero or negative value, instead of topping the battery to 100% before the daytime PV ramp
- keep negative-price runtime handling out of `HOME_UPS` when the battery is already at target/full, so spot negativity alone does not trigger pointless charging
- add regression tests for both the morning overcharge/curtailment pattern and the full-battery negative-price UPS fallback

## Validation
- full local pytest suite: `3154 passed, 27 skipped`
- targeted hybrid/planner regressions: `40 passed`
- local flake8, mypy, npm test, radon, and vulture completed successfully