### PR TITLE
release: prepare 2.3.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.19] - 2026-04-09
+
+### Fixed
+- Battery forecast planning now accepts usable partial adaptive load-profile payloads instead of collapsing to the legacy fallback path while profile warm-up is still in progress.
+- Forecast updates now rerun immediately when adaptive profiles arrive mid-bucket, so planned consumption and charging decisions no longer stay stuck on the stale flat fallback line until the next 15-minute refresh.
+- Planner load resolution now falls back to `load_avg` only when the selected adaptive profile is missing or unusable, with targeted regression coverage for partial profiles, same-bucket retries, and profile-update refresh triggers.
+
 ## [2.3.18] - 2026-04-08
 
 ### Fixed

--- a/custom_components/oig_cloud/battery_forecast/data/adaptive_consumption.py
+++ b/custom_components/oig_cloud/battery_forecast/data/adaptive_consumption.py
@@ -72,6 +72,12 @@ class AdaptiveConsumptionHelper:
         return SEASON_NAMES.get(season, season)
 
     @staticmethod
+    def _normalize_profile_payload(profile: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(profile, dict) or not profile:
+            return None
+        return profile
+
+    @staticmethod
     def _sum_profile_hours(hourly: Any, start_hour: int, start: int, end: int) -> float:
         total = 0.0
         if isinstance(hourly, list):
@@ -310,24 +316,31 @@ class AdaptiveConsumptionHelper:
 
             attrs = profiles_state.attributes
 
-            if "today_profile" not in attrs or "tomorrow_profile" not in attrs:
+            today_profile = self._normalize_profile_payload(attrs.get("today_profile"))
+            tomorrow_profile = self._normalize_profile_payload(
+                attrs.get("tomorrow_profile")
+            )
+
+            if not today_profile and not tomorrow_profile:
                 _LOGGER.debug(
-                    "Adaptive sensor missing today_profile or tomorrow_profile"
+                    "Adaptive sensor missing usable today/tomorrow profile payload"
                 )
                 return None
 
             result = {
-                "today_profile": attrs["today_profile"],
-                "tomorrow_profile": attrs["tomorrow_profile"],
                 "match_score": attrs.get("prediction_summary", {}).get(
                     "similarity_score", 0.0
                 ),
                 "prediction_summary": attrs.get("prediction_summary", {}),
             }
+            if today_profile:
+                result["today_profile"] = today_profile
+            if tomorrow_profile:
+                result["tomorrow_profile"] = tomorrow_profile
 
             _LOGGER.debug(
                 "✅ Adaptive prediction loaded: today=%.2f kWh, match_score=%.3f",
-                result["today_profile"].get("total_kwh", 0),
+                (today_profile or tomorrow_profile or {}).get("total_kwh", 0),
                 result["match_score"],
             )
 

--- a/custom_components/oig_cloud/battery_forecast/planning/forecast_update.py
+++ b/custom_components/oig_cloud/battery_forecast/planning/forecast_update.py
@@ -54,7 +54,10 @@ def _should_skip_bucket(sensor: Any, bucket_start: datetime) -> bool:
             cooldown_s=60.0,
         )
         return True
-    if sensor._last_forecast_bucket == bucket_start:
+    if (
+        sensor._last_forecast_bucket == bucket_start
+        and not getattr(sensor, "_profiles_dirty", False)
+    ):
         return True
     return False
 
@@ -236,7 +239,20 @@ def _resolve_load_kwh(
         )
 
     profile = _select_adaptive_profile(adaptive_profiles, timestamp, today)
+    if not profile:
+        return get_load_avg_for_timestamp(
+            timestamp,
+            load_avg_sensors,
+            state=sensor,
+        )
+
     hourly_kwh = _hourly_kwh_from_profile(sensor, profile, timestamp)
+    if hourly_kwh is None:
+        return get_load_avg_for_timestamp(
+            timestamp,
+            load_avg_sensors,
+            state=sensor,
+        )
     return hourly_kwh / 4.0
 
 
@@ -244,32 +260,81 @@ def _select_adaptive_profile(
     adaptive_profiles: dict[str, Any],
     timestamp: datetime,
     today: date,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
+    today_profile = adaptive_profiles.get("today_profile")
+    tomorrow_profile = adaptive_profiles.get("tomorrow_profile")
     if timestamp.date() == today:
-        return adaptive_profiles["today_profile"]
-    return adaptive_profiles.get("tomorrow_profile", adaptive_profiles["today_profile"])
+        return today_profile or tomorrow_profile
+    return tomorrow_profile or today_profile
+
+
+def _profile_has_hourly_series(profile: Any) -> bool:
+    if not isinstance(profile, dict):
+        return False
+    hourly_consumption = profile.get("hourly_consumption")
+    return isinstance(hourly_consumption, (list, dict)) and bool(hourly_consumption)
+
+
+def _profile_avg_kwh_h(profile: Any) -> float | None:
+    if not isinstance(profile, dict) or "avg_kwh_h" not in profile:
+        return None
+    try:
+        return float(profile.get("avg_kwh_h"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _has_usable_adaptive_profiles(adaptive_profiles: Any) -> bool:
+    if not isinstance(adaptive_profiles, dict):
+        return False
+    for profile_key in ("today_profile", "tomorrow_profile"):
+        profile = adaptive_profiles.get(profile_key)
+        if _profile_has_hourly_series(profile) or _profile_avg_kwh_h(profile) is not None:
+            return True
+    return False
 
 
 def _hourly_kwh_from_profile(
     sensor: Any, profile: dict[str, Any], timestamp: datetime
-) -> float:
+) -> float | None:
     hour = timestamp.hour
     start_hour = profile.get("start_hour", 0)
     index = hour - start_hour
-    hourly_consumption = profile.get("hourly_consumption", []) or []
-    if 0 <= index < len(hourly_consumption):
-        return hourly_consumption[index]
+    hourly_consumption = profile.get("hourly_consumption")
+    if isinstance(hourly_consumption, list) and 0 <= index < len(hourly_consumption):
+        return float(hourly_consumption[index])
+    if isinstance(hourly_consumption, dict):
+        value = hourly_consumption.get(hour)
+        if value is None:
+            value = hourly_consumption.get(index)
+        if value is not None:
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                pass
+
+    avg_kwh_h = _profile_avg_kwh_h(profile)
+    if avg_kwh_h is not None:
+        sensor._log_rate_limited(
+            "adaptive_profile_oob",
+            "debug",
+            "Adaptive profile hour out of range: hour=%s start=%s len=%s (using avg)",
+            hour,
+            start_hour,
+            len(hourly_consumption) if isinstance(hourly_consumption, (list, dict)) else 0,
+            cooldown_s=900.0,
+        )
+        return avg_kwh_h
 
     sensor._log_rate_limited(
-        "adaptive_profile_oob",
+        "adaptive_profile_missing_data",
         "debug",
-        "Adaptive profile hour out of range: hour=%s start=%s len=%s (using avg)",
+        "Adaptive profile missing usable data: hour=%s start=%s (falling back to load_avg)",
         hour,
         start_hour,
-        len(hourly_consumption),
         cooldown_s=900.0,
     )
-    return profile.get("avg_kwh_h", 0.5)
+    return None
 
 
 def _build_solar_kwh_list(
@@ -653,6 +718,7 @@ async def _prepare_forecast_inputs(sensor: Any, bucket_start: datetime) -> Optio
 async def async_update(sensor: Any) -> None:  # noqa: C901
     """Update sensor data."""
     mark_bucket_done = False
+    used_adaptive_profiles = False
     try:
         now_aware = dt_util.now()
         bucket_start = _bucket_start(now_aware)
@@ -684,6 +750,7 @@ async def async_update(sensor: Any) -> None:  # noqa: C901
             adaptive_helper,
             load_forecast,
         ) = prepared
+        used_adaptive_profiles = _has_usable_adaptive_profiles(adaptive_profiles)
         mark_bucket_done = True
 
         # ONE PLANNER: single planning pipeline.
@@ -725,7 +792,10 @@ async def async_update(sensor: Any) -> None:  # noqa: C901
                 )
                 # We intentionally keep profiles dirty until a successful compute; if async_update
                 # failed, the next tick will retry.
-                if sensor._timeline_data:
+                if sensor._timeline_data and (
+                    not getattr(sensor, "_profiles_dirty", False)
+                    or used_adaptive_profiles
+                ):
                     sensor._profiles_dirty = False
         except Exception:  # pragma: no cover
             pass  # nosec B110 pragma: no cover

--- a/custom_components/oig_cloud/battery_forecast/sensors/sensor_lifecycle.py
+++ b/custom_components/oig_cloud/battery_forecast/sensors/sensor_lifecycle.py
@@ -193,10 +193,11 @@ def _subscribe_profiles(sensor) -> None:
     async def _on_profiles_updated():
         await asyncio.sleep(0)
         sensor._profiles_dirty = True
+        sensor._schedule_forecast_retry(2.0)
         sensor._log_rate_limited(
-            "profiles_updated_deferred",
+            "profiles_updated_retry",
             "info",
-            " profiles_updated received - deferring forecast refresh to next 15-min tick",
+            " profiles_updated received - scheduling immediate forecast refresh",
             cooldown_s=300.0,
         )
 

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.18",
+  "version": "2.3.19",
   "zeroconf": []
 }

--- a/tests/test_adaptive_consumption_more.py
+++ b/tests/test_adaptive_consumption_more.py
@@ -129,6 +129,22 @@ async def test_get_adaptive_load_prediction_variants():
     result = await helper.get_adaptive_load_prediction()
     assert result["match_score"] == 0.0
 
+    state = DummyState({"today_profile": {"total_kwh": 1}})
+    hass = DummyHass({"sensor.oig_123_adaptive_load_profiles": state})
+    helper = module.AdaptiveConsumptionHelper(hass, "123")
+    result = await helper.get_adaptive_load_prediction()
+    assert result is not None
+    assert "today_profile" in result
+    assert "tomorrow_profile" not in result
+
+    state = DummyState({"tomorrow_profile": {"total_kwh": 2}})
+    hass = DummyHass({"sensor.oig_123_adaptive_load_profiles": state})
+    helper = module.AdaptiveConsumptionHelper(hass, "123")
+    result = await helper.get_adaptive_load_prediction()
+    assert result is not None
+    assert "today_profile" not in result
+    assert "tomorrow_profile" in result
+
     state = DummyState({})
     hass = DummyHass({"sensor.oig_123_adaptive_load_profiles": state})
     helper = module.AdaptiveConsumptionHelper(hass, "123")
@@ -139,7 +155,7 @@ async def test_get_adaptive_load_prediction_variants():
     assert await helper.get_adaptive_load_prediction() is None
 
     class BadStates(DummyStates):
-        def get(self, _entity_id):
+        def get(self, entity_id):
             raise RuntimeError("boom")
 
     bad_hass = DummyHass({})
@@ -175,7 +191,7 @@ def test_get_profiles_from_sensor_variants():
     assert helper.get_profiles_from_sensor() == {}
 
     class BadStates(DummyStates):
-        def get(self, _entity_id):
+        def get(self, entity_id):
             raise RuntimeError("boom")
 
     bad_hass = DummyHass({})

--- a/tests/test_forecast_update_more2.py
+++ b/tests/test_forecast_update_more2.py
@@ -564,6 +564,79 @@ async def test_async_update_load_forecast_exception_and_solar_error(monkeypatch)
     assert sensor._timeline_data
 
 
+def test_resolve_load_kwh_uses_today_profile_when_tomorrow_missing():
+    sensor = DummySensor()
+    timestamp = datetime(2025, 1, 2, 12, 0, 0)
+    adaptive_profiles = {
+        "today_profile": {
+            "start_hour": 0,
+            "hourly_consumption": [1.2] * 24,
+            "avg_kwh_h": 0.9,
+        }
+    }
+
+    load_kwh = forecast_update_module._resolve_load_kwh(
+        sensor,
+        timestamp,
+        adaptive_profiles,
+        load_avg_sensors={},
+        today=datetime(2025, 1, 1).date(),
+    )
+
+    assert load_kwh == pytest.approx(0.3)
+
+
+def test_resolve_load_kwh_falls_back_when_adaptive_profile_missing_data(monkeypatch):
+    sensor = DummySensor()
+    timestamp = datetime(2025, 1, 1, 12, 0, 0)
+    adaptive_profiles = {"today_profile": {"start_hour": 0}}
+
+    monkeypatch.setattr(
+        forecast_update_module,
+        "get_load_avg_for_timestamp",
+        lambda *_a, **_k: 0.18,
+    )
+
+    load_kwh = forecast_update_module._resolve_load_kwh(
+        sensor,
+        timestamp,
+        adaptive_profiles,
+        load_avg_sensors={},
+        today=timestamp.date(),
+    )
+
+    assert load_kwh == pytest.approx(0.18)
+
+
+def test_should_skip_bucket_allows_profiles_dirty_rerun():
+    sensor = DummySensor()
+    bucket_start = datetime(2025, 1, 1, 12, 0, 0)
+    sensor._last_forecast_bucket = bucket_start
+    sensor._profiles_dirty = True
+
+    assert forecast_update_module._should_skip_bucket(sensor, bucket_start) is False
+
+
+def test_has_usable_adaptive_profiles_accepts_partial_profile():
+    adaptive_profiles = {
+        "today_profile": {
+            "avg_kwh_h": 0.7,
+        }
+    }
+
+    assert forecast_update_module._has_usable_adaptive_profiles(adaptive_profiles) is True
+
+
+def test_hourly_kwh_from_profile_returns_none_without_series_or_avg():
+    sensor = DummySensor()
+    value = forecast_update_module._hourly_kwh_from_profile(
+        sensor,
+        {"start_hour": 0},
+        datetime(2025, 1, 1, 12, 0, 0),
+    )
+    assert value is None
+
+
 @pytest.mark.asyncio
 async def test_async_update_truncates_horizon(monkeypatch):
     fixed_now = datetime(2025, 1, 1, 12, 0, 0)

--- a/tests/test_sensor_lifecycle.py
+++ b/tests/test_sensor_lifecycle.py
@@ -62,6 +62,7 @@ class DummySensor:
 
         self._update_calls = 0
         self._create_task_calls = []
+        self._schedule_forecast_retry_calls = []
         self._backfill_called = False
         self._aggregate_daily_called = None
         self._aggregate_weekly_called = None
@@ -97,6 +98,9 @@ class DummySensor:
 
     def _create_task_threadsafe(self, func, *args):
         self._create_task_calls.append((func, args))
+
+    def _schedule_forecast_retry(self, delay_seconds):
+        self._schedule_forecast_retry_calls.append(delay_seconds)
 
 
 @pytest.mark.asyncio
@@ -266,6 +270,29 @@ async def test_async_added_to_hass_callbacks(monkeypatch):
     for coro, _name in sensor.hass.background_created:
         if hasattr(coro, "close"):
             coro.close()
+
+
+@pytest.mark.asyncio
+async def test_profiles_updated_schedules_immediate_refresh(monkeypatch):
+    sensor = DummySensor()
+
+    callback_holder = {}
+
+    def _connect(_hass, _signal, callback):
+        callback_holder["callback"] = callback
+        return lambda: None
+
+    async def _sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(sensor_lifecycle, "async_dispatcher_connect", _connect)
+    monkeypatch.setattr(sensor_lifecycle.asyncio, "sleep", _sleep)
+
+    sensor_lifecycle._subscribe_profiles(sensor)
+    await callback_holder["callback"]()
+
+    assert sensor._profiles_dirty is True
+    assert sensor._schedule_forecast_retry_calls == [2.0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- accept usable partial adaptive load-profile payloads so planner updates do not collapse to the stale flat fallback line during warm-up
- rerun the forecast immediately when adaptive profiles arrive mid-bucket and preserve same-bucket recomputes while profiles are dirty
- bump the integration to 2.3.19 and document the planner fallback fix in the changelog

## Validation
- `.venv/bin/python -m pytest tests/test_forecast_update.py tests/test_forecast_update_more2.py tests/test_adaptive_consumption_more.py tests/test_sensor_lifecycle.py tests/test_load_and_solar_profiles.py tests/test_adaptive_consumption.py tests/test_battery_forecast_module.py tests/test_battery_forecast_remaining_coverage.py -q`
- review-work passed: goal fit, QA, code quality, security, and context mining
