### PR TITLE
release: prepare 2.3.21 shield UI follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.21] - 2026-04-10
+
+### Fixed
+- Grid-delivery updates in Dashboard V2 now avoid redundant `limited` mode writes when the inverter is already limited or a limited-mode step is already pending, so limit-only changes no longer resend the same mode before applying the new export limit.
+- Confirmation dialogs now render trusted acknowledgement markup correctly in the shadow DOM, fixing the visible `<strong>` tag text that still leaked into the popup.
+- Grid-delivery buttons now keep the limited state visually active during shield-driven transitions, so the control panel no longer shows disabled exports while limited export remains the effective current state.
+
 ## [2.3.20] - 2026-04-10
 
 ### Fixed

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.20",
+  "version": "2.3.21",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/www_v2/src/__tests__/confirm-dialog-ack.test.ts
+++ b/custom_components/oig_cloud/www_v2/src/__tests__/confirm-dialog-ack.test.ts
@@ -381,7 +381,7 @@ describe('OigConfirmDialog — acknowledgementText render branch (lines 342-344)
     el.remove();
   });
 
-  it('renders custom acknowledgementText via renderHTML when acknowledgementText is provided', async () => {
+  it('renders custom acknowledgementText as real DOM markup — no literal angle-bracket tags visible', async () => {
     el.showDialog({
       title: 'Test',
       message: 'Msg',
@@ -394,9 +394,27 @@ describe('OigConfirmDialog — acknowledgementText render branch (lines 342-344)
     const label = el.shadowRoot!.querySelector('.ack-wrapper label');
     expect(label).not.toBeNull();
 
-    const span = label!.querySelector('span');
-    expect(span).not.toBeNull();
-    expect(span!.innerHTML).toContain('<strong>Vlastní souhlas</strong>');
+    expect(label!.textContent).not.toContain('<strong>');
+    expect(label!.textContent).not.toContain('</strong>');
+    expect(label!.textContent).toContain('Vlastní souhlas');
+  });
+
+  it('renders acknowledgementText strong tag as a DOM element in shadow DOM', async () => {
+    el.showDialog({
+      title: 'Test',
+      message: 'Msg',
+      requireAcknowledgement: true,
+      acknowledgementText: '<strong>Vlastní souhlas</strong> s podmínkami.',
+    });
+
+    await (el as unknown as { updateComplete: Promise<boolean> }).updateComplete;
+
+    const label = el.shadowRoot!.querySelector('.ack-wrapper label');
+    expect(label).not.toBeNull();
+
+    const strongEl = label!.querySelector('strong');
+    expect(strongEl).not.toBeNull();
+    expect(strongEl!.textContent).toBe('Vlastní souhlas');
   });
 
   it('renders default acknowledgementText template when acknowledgementText is absent', async () => {

--- a/custom_components/oig_cloud/www_v2/src/__tests__/grid-mode-control-panel.test.ts
+++ b/custom_components/oig_cloud/www_v2/src/__tests__/grid-mode-control-panel.test.ts
@@ -170,3 +170,72 @@ describe('OigGridDeliverySelector — activeLimitLabel render branch', () => {
     expect(limitLabel?.values).toContain(7777);
   });
 });
+
+describe('OigGridDeliverySelector — limited button stays visually active during service transition', () => {
+  function getButtonClasses(
+    value: 'off' | 'on' | 'limited',
+    buttonStates: Record<'off' | 'on' | 'limited', 'idle' | 'active' | 'pending' | 'processing' | 'disabled-by-service'>,
+  ): Record<'off' | 'on' | 'limited', string> {
+    const el = new OigGridDeliverySelector();
+    el.value = value;
+    el.limit = 5000;
+    el.buttonStates = buttonStates;
+
+    const rendered = Reflect.apply(
+      Reflect.get(Object.getPrototypeOf(el), 'render'),
+      el,
+      [],
+    ) as { values?: unknown[] } | null;
+
+    const modeButtonsTemplate = rendered?.values?.[1] as Array<{ values?: unknown[] }> | null;
+    if (!Array.isArray(modeButtonsTemplate)) return { off: '', on: '', limited: '' };
+
+    const keys: Array<'off' | 'on' | 'limited'> = ['off', 'on', 'limited'];
+    const result: Record<'off' | 'on' | 'limited', string> = { off: '', on: '', limited: '' };
+    keys.forEach((key, i) => {
+      const tpl = modeButtonsTemplate[i] as { values?: unknown[] } | null;
+      result[key] = String(tpl?.values?.[0] ?? '');
+    });
+    return result;
+  }
+
+  it('limited button class is "active disabled-by-service" when value=limited and shield is changing to off', () => {
+    const classes = getButtonClasses('limited', {
+      off: 'processing',
+      on: 'disabled-by-service',
+      limited: 'disabled-by-service',
+    });
+    expect(classes.limited).toBe('active disabled-by-service');
+  });
+
+  it('limited button class is "active" when value=limited and no service change is pending', () => {
+    const classes = getButtonClasses('limited', {
+      off: 'idle',
+      on: 'idle',
+      limited: 'active',
+    });
+    expect(classes.limited).toBe('active');
+  });
+
+  it('off button class is not active when value=limited even if shield disabled it', () => {
+    const classes = getButtonClasses('limited', {
+      off: 'disabled-by-service',
+      on: 'disabled-by-service',
+      limited: 'disabled-by-service',
+    });
+    expect(classes.off).toBe('disabled-by-service');
+    expect(classes.on).toBe('disabled-by-service');
+    expect(classes.limited).toBe('active disabled-by-service');
+  });
+
+  it('no button gets active-override when value=off and all states are idle', () => {
+    const classes = getButtonClasses('off', {
+      off: 'active',
+      on: 'idle',
+      limited: 'idle',
+    });
+    expect(classes.off).toBe('active');
+    expect(classes.on).toBe('idle');
+    expect(classes.limited).toBe('idle');
+  });
+});

--- a/custom_components/oig_cloud/www_v2/src/__tests__/shield-controller.test.ts
+++ b/custom_components/oig_cloud/www_v2/src/__tests__/shield-controller.test.ts
@@ -274,7 +274,18 @@ describe('ShieldController service calls', () => {
     expect(call[2]).not.toHaveProperty('mode');
   });
 
-  it('setGridDelivery sends both mode and limit when not yet in limited mode', async () => {
+  it('setGridDelivery sends both mode and limit when switching from off to limited', async () => {
+    mockStoreState.gridMode = 'Vypnuto';
+    const { ShieldController } = await import('@/data/shield-controller');
+    const controller = new ShieldController();
+    controller.refresh();
+
+    await controller.setGridDelivery('limited', 4000);
+    const call = (haClient.callService as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[2]).toMatchObject({ mode: 'limited', limit: 4000 });
+  });
+
+  it('setGridDelivery sends both mode and limit when switching from on to limited', async () => {
     mockStoreState.gridMode = 'Zapnuto';
     const { ShieldController } = await import('@/data/shield-controller');
     const controller = new ShieldController();
@@ -283,6 +294,52 @@ describe('ShieldController service calls', () => {
     await controller.setGridDelivery('limited', 4000);
     const call = (haClient.callService as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[2]).toMatchObject({ mode: 'limited', limit: 4000 });
+  });
+
+  it('setGridDelivery sends only limit when store already reports limited but cached state is stale', async () => {
+    const { ShieldController } = await import('@/data/shield-controller');
+    const controller = new ShieldController();
+
+    mockStoreState.gridMode = 'Zapnuto';
+    controller.refresh();
+    expect(controller.getState().currentGridDelivery).toBe('on');
+
+    mockStoreState.gridMode = 'Omezeno';
+
+    await controller.setGridDelivery('limited', 4200);
+
+    const call = (haClient.callService as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[2]).toMatchObject({ limit: 4200 });
+    expect(call[2]).not.toHaveProperty('mode');
+  });
+
+  it('setGridDelivery sends only limit when limited mode is already pending before numeric limit step', async () => {
+    mockStoreState.status = 'running';
+    mockStoreState.queueCount = 2;
+    mockStoreState.gridMode = 'Probíhá změna';
+    mockStoreState.activityAttrs = {
+      running_requests: [
+        {
+          service: 'set_grid_delivery',
+          grid_delivery_step: 'mode',
+          params: { mode: 'limited', _grid_delivery_step: 'mode' },
+          targets: [{ param: 'mode', value: 'Omezeno', entity_id: 'sensor.invertor_prms_to_grid', from: 'Zapnuto', to: 'Omezeno', current: 'Zapnuto' }],
+          changes: [],
+          started_at: '2026-04-09T12:00:00Z',
+        },
+      ],
+      queued_requests: [],
+    };
+
+    const { ShieldController } = await import('@/data/shield-controller');
+    const controller = new ShieldController();
+    controller.refresh();
+
+    await controller.setGridDelivery('limited', 3600);
+
+    const call = (haClient.callService as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[2]).toMatchObject({ limit: 3600 });
+    expect(call[2]).not.toHaveProperty('mode');
   });
 
   it('setGridDelivery sends limit only when delivery is non-limited with limit param', async () => {
@@ -413,6 +470,70 @@ describe('ShieldController button state helpers', () => {
     controller.refresh();
 
     expect(controller.getGridDeliveryButtonState('limited')).toBe('processing');
+    expect(controller.getGridDeliveryButtonState('off')).toBe('disabled-by-service');
+  });
+
+  it('getGridDeliveryButtonState keeps current limited active during queued transition away from limited', async () => {
+    const { ShieldController } = await import('@/data/shield-controller');
+    const controller = new ShieldController();
+
+    mockStoreState.gridMode = 'Omezeno';
+    mockStoreState.activityAttrs = { running_requests: [], queued_requests: [] };
+    controller.refresh();
+
+    mockStoreState.status = 'idle';
+    mockStoreState.queueCount = 1;
+    mockStoreState.gridMode = 'Omezeno';
+    mockStoreState.activityAttrs = {
+      running_requests: [],
+      queued_requests: [
+        {
+          service: 'set_grid_delivery',
+          grid_delivery_step: 'mode',
+          params: { mode: 'off', _grid_delivery_step: 'mode' },
+          targets: [{ param: 'mode', value: 'Vypnuto', entity_id: 'sensor.invertor_prms_to_grid', from: 'Omezeno', to: 'Vypnuto', current: 'Omezeno' }],
+          changes: [],
+          queued_at: '2026-04-09T12:00:00Z',
+        },
+      ],
+    };
+
+    controller.refresh();
+
+    expect(controller.getGridDeliveryButtonState('limited')).toBe('active');
+    expect(controller.getGridDeliveryButtonState('off')).toBe('pending');
+    expect(controller.getGridDeliveryButtonState('on')).toBe('disabled-by-service');
+  });
+
+  it('getGridDeliveryButtonState keeps current limited active during running transition away from limited', async () => {
+    const { ShieldController } = await import('@/data/shield-controller');
+    const controller = new ShieldController();
+
+    mockStoreState.gridMode = 'Omezeno';
+    mockStoreState.activityAttrs = { running_requests: [], queued_requests: [] };
+    controller.refresh();
+
+    mockStoreState.status = 'running';
+    mockStoreState.queueCount = 1;
+    mockStoreState.gridMode = 'Probíhá změna';
+    mockStoreState.activityAttrs = {
+      running_requests: [
+        {
+          service: 'set_grid_delivery',
+          grid_delivery_step: 'mode',
+          params: { mode: 'on', _grid_delivery_step: 'mode' },
+          targets: [{ param: 'mode', value: 'Zapnuto', entity_id: 'sensor.invertor_prms_to_grid', from: 'Omezeno', to: 'Zapnuto', current: 'Omezeno' }],
+          changes: [],
+          started_at: '2026-04-09T12:00:00Z',
+        },
+      ],
+      queued_requests: [],
+    };
+
+    controller.refresh();
+
+    expect(controller.getGridDeliveryButtonState('limited')).toBe('active');
+    expect(controller.getGridDeliveryButtonState('on')).toBe('processing');
     expect(controller.getGridDeliveryButtonState('off')).toBe('disabled-by-service');
   });
 
@@ -588,6 +709,20 @@ describe('ShieldController structured split grid parsing', () => {
     expect(controller.getState().currentGridDelivery).toBe('limited');
 
     mockStoreState.gridMode = 'Probíhá změna';
+    controller.refresh();
+    expect(controller.getState().currentGridDelivery).toBe('limited');
+  });
+
+  it('preserves previous grid mode during prefixed Probíhá změna transition refreshes', async () => {
+    const { ShieldController } = await import('@/data/shield-controller');
+    const controller = new ShieldController();
+
+    mockStoreState.activityAttrs = { running_requests: [], queued_requests: [] };
+    mockStoreState.gridMode = 'Omezeno';
+    controller.refresh();
+    expect(controller.getState().currentGridDelivery).toBe('limited');
+
+    mockStoreState.gridMode = 'Probíhá změna režimu';
     controller.refresh();
     expect(controller.getState().currentGridDelivery).toBe('limited');
   });

--- a/custom_components/oig_cloud/www_v2/src/data/shield-controller.ts
+++ b/custom_components/oig_cloud/www_v2/src/data/shield-controller.ts
@@ -48,6 +48,10 @@ export class ShieldController {
   private queueUpdateInterval: number | null = null;
   private started = false;
 
+  private isGridDeliveryTransition(rawValue: string): boolean {
+    return rawValue.trim().toLowerCase().includes('probíhá změna');
+  }
+
   // --------------------------------------------------------------------------
   // Lifecycle
   // --------------------------------------------------------------------------
@@ -150,7 +154,7 @@ export class ShieldController {
 
       // Normalize current values
       const currentBoxMode = BOX_MODE_SENSOR_MAP[boxModeRaw.trim()] ?? 'home_1';
-      const currentGridDelivery = gridModeRaw.trim() === 'Probíhá změna'
+      const currentGridDelivery = this.isGridDeliveryTransition(gridModeRaw)
         ? this.state.currentGridDelivery
         : resolveGridDelivery(gridModeRaw);
       const currentBoilerMode = BOILER_MODE_SENSOR_MAP[boilerModeRaw.trim()] ?? 'cbb';
@@ -164,7 +168,7 @@ export class ShieldController {
       const pendingServices = new Map<ShieldServiceType, string>();
       const changingServices = new Set<ShieldServiceType>();
 
-      if (gridModeRaw.trim() === 'Probíhá změna') {
+      if (this.isGridDeliveryTransition(gridModeRaw)) {
         changingServices.add('grid_mode');
       }
 
@@ -406,6 +410,48 @@ export class ShieldController {
     }
   }
 
+  private getGridDeliveryTransitionState(): 'pending' | 'processing' {
+    return this.state.status === 'running' ? 'processing' : 'pending';
+  }
+
+  private getPendingGridDeliveryTarget(): GridDelivery | null {
+    const pendingTarget = this.state.pendingServices.get('grid_mode');
+    if (!pendingTarget) {
+      return null;
+    }
+    return GRID_DELIVERY_SENSOR_MAP[pendingTarget] ?? null;
+  }
+
+  private isLimitedGridDeliveryActiveOrPending(): boolean {
+    if (this.state.pendingServices.has('grid_limit')) {
+      return true;
+    }
+
+    if (this.getPendingGridDeliveryTarget() === 'limited') {
+      return true;
+    }
+
+    const store = getEntityStore();
+    if (!store) {
+      return this.state.currentGridDelivery === 'limited';
+    }
+
+    const rawGridMode = store.getString(store.getSensorId('invertor_prms_to_grid')).value;
+    if (!rawGridMode.trim()) {
+      return this.state.currentGridDelivery === 'limited';
+    }
+
+    if (this.isGridDeliveryTransition(rawGridMode)) {
+      return this.state.currentGridDelivery === 'limited';
+    }
+
+    return resolveGridDelivery(rawGridMode) === 'limited';
+  }
+
+  private needsGridModeChangeForLimitedRequest(): boolean {
+    return !this.isLimitedGridDeliveryActiveOrPending();
+  }
+
   // --------------------------------------------------------------------------
   // Button state helpers (for use by selector components)
   // --------------------------------------------------------------------------
@@ -423,28 +469,35 @@ export class ShieldController {
   }
 
   getGridDeliveryButtonState(delivery: GridDelivery): 'active' | 'pending' | 'processing' | 'disabled-by-service' | 'idle' {
+    const transitionState = this.getGridDeliveryTransitionState();
+
     // Grid mode changing
     if (this.state.changingServices.has('grid_mode')) {
-      const pendingTarget = this.state.pendingServices.get('grid_mode');
-      if (pendingTarget) {
-        const pendingDelivery = GRID_DELIVERY_SENSOR_MAP[pendingTarget];
-        if (pendingDelivery === delivery) {
-          return this.state.status === 'running' ? 'processing' : 'pending';
-        }
+      const pendingDelivery = this.getPendingGridDeliveryTarget();
+      if (pendingDelivery === delivery) {
+        return transitionState;
       }
+
       // If limit is pending and delivery is 'limited', highlight it
       if (this.state.pendingServices.has('grid_limit') && delivery === 'limited') {
-        return this.state.status === 'running' ? 'processing' : 'pending';
+        return transitionState;
       }
+
+      if (delivery === 'limited' && this.state.currentGridDelivery === 'limited') {
+        return 'active';
+      }
+
       return 'disabled-by-service';
     }
+
     // Only limit is changing
     if (this.state.changingServices.has('grid_limit')) {
       if (delivery === 'limited') {
-        return this.state.status === 'running' ? 'processing' : 'pending';
+        return transitionState;
       }
       return 'disabled-by-service';
     }
+
     return this.state.currentGridDelivery === delivery ? 'active' : 'idle';
   }
 
@@ -508,13 +561,10 @@ export class ShieldController {
 
     // If limited with a limit value, send both mode + limit
     if (delivery === 'limited' && limit != null) {
-      // If already in limited mode, just change the limit
-      if (this.state.currentGridDelivery === 'limited') {
-        data.limit = limit;
-      } else {
+      if (this.needsGridModeChangeForLimitedRequest()) {
         data.mode = delivery;
-        data.limit = limit;
       }
+      data.limit = limit;
     } else if (limit != null) {
       // Only changing limit (grid delivery is already limited)
       data.limit = limit;

--- a/custom_components/oig_cloud/www_v2/src/ui/features/control-panel/confirm-dialog.ts
+++ b/custom_components/oig_cloud/www_v2/src/ui/features/control-panel/confirm-dialog.ts
@@ -12,6 +12,7 @@
 
 import { LitElement, html, css, unsafeCSS, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { CSS_VARS } from '@/ui/theme';
 import { ConfirmDialogConfig, ConfirmDialogResult } from './types';
 
@@ -366,14 +367,8 @@ export class OigConfirmDialog extends LitElement {
     `;
   }
 
-  /** Render a string that may contain HTML as unsafeHTML */
   private renderHTML(text: string) {
-    // Simple approach: create a temporary div, set innerHTML, return content
-    // For security in this internal dashboard context, this is acceptable
-    const div = document.createElement('div');
-    div.innerHTML = text;
-    // We use a span wrapper via lit's html to keep it reactive
-    return html`<span .innerHTML=${text}></span>`;
+    return unsafeHTML(text);
   }
 }
 

--- a/custom_components/oig_cloud/www_v2/src/ui/features/control-panel/selectors.ts
+++ b/custom_components/oig_cloud/www_v2/src/ui/features/control-panel/selectors.ts
@@ -280,10 +280,14 @@ export class OigGridDeliverySelector extends LitElement {
       <div class="mode-buttons">
         ${options.map(opt => {
           const state = this.buttonStates[opt.value];
+          const isCurrentValue = opt.value === this.value;
           const isDisabled = this.disabled || state === 'pending' || state === 'processing' || state === 'disabled-by-service';
+          const effectiveClass = (isCurrentValue && state === 'disabled-by-service')
+            ? 'active disabled-by-service'
+            : state;
           return html`
             <button
-              class="mode-btn ${state}"
+              class="mode-btn ${effectiveClass}"
               ?disabled=${isDisabled}
               @click=${() => this.onDeliveryClick(opt.value)}
             >


### PR DESCRIPTION
## Summary
- avoid redundant `limited` grid-delivery mode writes when only the export limit needs to change
- render confirmation acknowledgement markup correctly in the dashboard V2 dialog
- keep the limited grid-delivery button visually active during shield-driven transitions

## Release
- bump integration version to `2.3.21`
- add `2.3.21` changelog entry for the shipped hotfixes