### PR TITLE
fix: shield redundant limited mode, suffix sensor lookup, and mypy narrowing (2.3.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.22] - 2026-04-11
+
+### Fixed
+- Shield `setGridDelivery` now correctly avoids redundant `mode: limited` writes when the inverter is already in limited mode or a limited-mode step is already pending, so limit-only updates no longer re-enqueue the same mode.
+- Dashboard V2 control panel now reads grid-delivery sensors via `findSensorId()` instead of `getSensorId()`, fixing the missing/off state display for devices that expose suffixed entity IDs (e.g. `_2`).
+- `adaptive_load_profiles_sensor.py` now narrows `self._hass` before passing it to recorder executor jobs, resolving a mypy type error without suppressions.
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [2.3.21] - 2026-04-10
 
 ### Fixed

--- a/custom_components/oig_cloud/entities/adaptive_load_profiles_sensor.py
+++ b/custom_components/oig_cloud/entities/adaptive_load_profiles_sensor.py
@@ -498,13 +498,16 @@ class OigCloudAdaptiveLoadProfilesSensor(SensorEntity):
             recorder_instance = self._get_recorder_instance()
             if not recorder_instance:
                 return []
+            hass = self._hass
+            if hass is None:
+                return []
             start_ts = int(dt_util.as_utc(start_time).timestamp())
             end_ts = int(dt_util.as_utc(end_time).timestamp())
 
             stats_rows = await recorder_instance.async_add_executor_job(
                 partial(
                     _query_hourly_statistics,
-                    self._hass,
+                    hass,
                     sensor_entity_id,
                     start_ts,
                     end_ts,

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.21",
+  "version": "2.3.22",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/www_v2/src/__tests__/shield-controller.test.ts
+++ b/custom_components/oig_cloud/www_v2/src/__tests__/shield-controller.test.ts
@@ -9,11 +9,20 @@ const mockStoreState = {
   gridMode: 'Omezeno',
   gridLimit: 5400,
   boilerMode: 'CBB',
+  useGridSuffixSensors: false,
 };
 
 vi.mock('@/data/entity-store', () => ({
   getEntityStore: vi.fn(() => ({
-    findSensorId: (sensorName: string) => `sensor.${sensorName}`,
+    findSensorId: (sensorName: string) => {
+      if (mockStoreState.useGridSuffixSensors && sensorName === 'invertor_prms_to_grid') {
+        return 'sensor.invertor_prms_to_grid_2';
+      }
+      if (mockStoreState.useGridSuffixSensors && sensorName === 'invertor_prm1_p_max_feed_grid') {
+        return 'sensor.invertor_prm1_p_max_feed_grid_2';
+      }
+      return `sensor.${sensorName}`;
+    },
     getSensorId: (sensorName: string) => `sensor.${sensorName}`,
     get: (entityId: string) => {
       if (entityId === 'sensor.service_shield_activity') {
@@ -31,6 +40,11 @@ vi.mock('@/data/entity-store', () => ({
         case 'sensor.box_prms_mode':
           return { value: mockStoreState.boxMode, lastUpdated: null, attributes: {}, exists: true };
         case 'sensor.invertor_prms_to_grid':
+          if (mockStoreState.useGridSuffixSensors) {
+            return { value: '', lastUpdated: null, attributes: {}, exists: false };
+          }
+          return { value: mockStoreState.gridMode, lastUpdated: null, attributes: {}, exists: true };
+        case 'sensor.invertor_prms_to_grid_2':
           return { value: mockStoreState.gridMode, lastUpdated: null, attributes: {}, exists: true };
         case 'sensor.boiler_manual_mode':
           return { value: mockStoreState.boilerMode, lastUpdated: null, attributes: {}, exists: true };
@@ -43,6 +57,11 @@ vi.mock('@/data/entity-store', () => ({
         case 'sensor.service_shield_queue':
           return { value: mockStoreState.queueCount, lastUpdated: null, attributes: {}, exists: true };
         case 'sensor.invertor_prm1_p_max_feed_grid':
+          if (mockStoreState.useGridSuffixSensors) {
+            return { value: 0, lastUpdated: null, attributes: {}, exists: false };
+          }
+          return { value: mockStoreState.gridLimit, lastUpdated: null, attributes: {}, exists: true };
+        case 'sensor.invertor_prm1_p_max_feed_grid_2':
           return { value: mockStoreState.gridLimit, lastUpdated: null, attributes: {}, exists: true };
         default:
           return { value: 0, lastUpdated: null, attributes: {}, exists: false };
@@ -72,6 +91,7 @@ describe('ShieldController lifecycle — start / stop / subscribe', () => {
     mockStoreState.gridMode = 'Omezeno';
     mockStoreState.gridLimit = 5400;
     mockStoreState.boilerMode = 'CBB';
+    mockStoreState.useGridSuffixSensors = false;
     vi.resetModules();
     vi.clearAllMocks();
   });
@@ -342,6 +362,63 @@ describe('ShieldController service calls', () => {
     expect(call[2]).not.toHaveProperty('mode');
   });
 
+  it('setGridDelivery sends only limit when grid_mode is already pending even if raw sensor still says off', async () => {
+    mockStoreState.status = 'idle';
+    mockStoreState.queueCount = 1;
+    mockStoreState.gridMode = 'Vypnuto';
+    mockStoreState.activityAttrs = {
+      running_requests: [],
+      queued_requests: [
+        {
+          service: 'set_grid_delivery',
+          grid_delivery_step: 'mode',
+          params: { mode: 'limited', _grid_delivery_step: 'mode' },
+          targets: [{ param: 'mode', value: 'Omezeno', entity_id: 'sensor.invertor_prms_to_grid', from: 'Vypnuto', to: 'Omezeno', current: 'Vypnuto' }],
+          changes: [],
+          queued_at: '2026-04-09T12:00:00Z',
+        },
+      ],
+    };
+
+    const { ShieldController } = await import('@/data/shield-controller');
+    const controller = new ShieldController();
+    controller.refresh();
+
+    await controller.setGridDelivery('limited', 5400);
+
+    const call = (haClient.callService as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[2]).toMatchObject({ limit: 5400 });
+    expect(call[2]).not.toHaveProperty('mode');
+  });
+
+  it('setGridDelivery still sends mode and limit when pending grid_mode targets on instead of limited', async () => {
+    mockStoreState.status = 'idle';
+    mockStoreState.queueCount = 1;
+    mockStoreState.gridMode = 'Vypnuto';
+    mockStoreState.activityAttrs = {
+      running_requests: [],
+      queued_requests: [
+        {
+          service: 'set_grid_delivery',
+          grid_delivery_step: 'mode',
+          params: { mode: 'on', _grid_delivery_step: 'mode' },
+          targets: [{ param: 'mode', value: 'Zapnuto', entity_id: 'sensor.invertor_prms_to_grid', from: 'Vypnuto', to: 'Zapnuto', current: 'Vypnuto' }],
+          changes: [],
+          queued_at: '2026-04-09T12:00:00Z',
+        },
+      ],
+    };
+
+    const { ShieldController } = await import('@/data/shield-controller');
+    const controller = new ShieldController();
+    controller.refresh();
+
+    await controller.setGridDelivery('limited', 5400);
+
+    const call = (haClient.callService as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[2]).toMatchObject({ mode: 'limited', limit: 5400 });
+  });
+
   it('setGridDelivery sends limit only when delivery is non-limited with limit param', async () => {
     const { ShieldController } = await import('@/data/shield-controller');
     const controller = new ShieldController();
@@ -444,6 +521,17 @@ describe('ShieldController button state helpers', () => {
     const controller = new ShieldController();
     controller.refresh();
 
+    expect(controller.getGridDeliveryButtonState('limited')).toBe('active');
+    expect(controller.getGridDeliveryButtonState('off')).toBe('idle');
+  });
+
+  it('refresh reads suffix-matched grid sensors via findSensorId so limited mode does not fall back to off', async () => {
+    const { ShieldController } = await import('@/data/shield-controller');
+    const controller = new ShieldController();
+    mockStoreState.useGridSuffixSensors = true;
+    controller.refresh();
+
+    expect(controller.getState().currentGridDelivery).toBe('limited');
     expect(controller.getGridDeliveryButtonState('limited')).toBe('active');
     expect(controller.getGridDeliveryButtonState('off')).toBe('idle');
   });

--- a/custom_components/oig_cloud/www_v2/src/data/shield-controller.ts
+++ b/custom_components/oig_cloud/www_v2/src/data/shield-controller.ts
@@ -147,10 +147,10 @@ export class ShieldController {
       const queueCount = store.getNumeric(queueSensorId).value;
 
       // --- Current actual values ---
-      const boxModeRaw = store.getString(store.getSensorId('box_prms_mode')).value;
-      const gridModeRaw = store.getString(store.getSensorId('invertor_prms_to_grid')).value;
-      const gridLimit = store.getNumeric(store.getSensorId('invertor_prm1_p_max_feed_grid')).value;
-      const boilerModeRaw = store.getString(store.getSensorId('boiler_manual_mode')).value;
+      const boxModeRaw = store.getString(store.findSensorId('box_prms_mode')).value;
+      const gridModeRaw = store.getString(store.findSensorId('invertor_prms_to_grid')).value;
+      const gridLimit = store.getNumeric(store.findSensorId('invertor_prm1_p_max_feed_grid')).value;
+      const boilerModeRaw = store.getString(store.findSensorId('boiler_manual_mode')).value;
 
       // Normalize current values
       const currentBoxMode = BOX_MODE_SENSOR_MAP[boxModeRaw.trim()] ?? 'home_1';
@@ -423,11 +423,11 @@ export class ShieldController {
   }
 
   private isLimitedGridDeliveryActiveOrPending(): boolean {
-    if (this.state.pendingServices.has('grid_limit')) {
+    if (this.getPendingGridDeliveryTarget() === 'limited') {
       return true;
     }
 
-    if (this.getPendingGridDeliveryTarget() === 'limited') {
+    if (this.state.pendingServices.has('grid_limit')) {
       return true;
     }
 
@@ -436,7 +436,7 @@ export class ShieldController {
       return this.state.currentGridDelivery === 'limited';
     }
 
-    const rawGridMode = store.getString(store.getSensorId('invertor_prms_to_grid')).value;
+    const rawGridMode = store.getString(store.findSensorId('invertor_prms_to_grid')).value;
     if (!rawGridMode.trim()) {
       return this.state.currentGridDelivery === 'limited';
     }


### PR DESCRIPTION
## Summary

Three fixes targeting the 2.3.22 release:

1. **Shield redundant limited mode** - `setGridDelivery` now correctly avoids redundant `mode: limited` writes when the inverter is already in limited mode or a limited-mode step is already pending.

2. **Suffix sensor lookup** - Dashboard V2 control panel now reads grid-delivery sensors via `findSensorId()` instead of `getSensorId()`, fixing the missing/off state display for devices with suffixed entity IDs (e.g. `_2`).

3. **Mypy narrowing** - `adaptive_load_profiles_sensor.py` now narrows `self._hass` before passing it to recorder executor jobs, resolving a mypy type error without suppressions.

## Verification

- Frontend targeted tests: passed
- Python targeted tests: passed
- mypy: clean