### PR TITLE
Release v2.3.27 — Legacy proxy entity format hotfix

### DIFF
--- a/.sisyphus/evidence/legacy-proxy-format-fix.txt
+++ b/.sisyphus/evidence/legacy-proxy-format-fix.txt
@@ -1,0 +1,41 @@
+Legacy proxy entity format fix - evidence
+==========================================
+
+Date: 2026-04-16
+Task: Fix oig-cloud local/proxy entity mapping to support BOTH current oig_local_ format AND legacy format without oig_local_ prefix.
+
+Changes made:
+1. custom_components/oig_cloud/core/local_mapper.py
+   - normalize_proxy_entity_id() now accepts both:
+     * {domain}.oig_local_{device_id}_{table}_{key}[_cfg] (current)
+     * {domain}.{device_id}_{table}_{key}[_cfg] (legacy)
+   - iter_local_entities() no longer hardcodes oig_local_ prefix; it relies on normalize_proxy_entity_id() for filtering.
+
+2. custom_components/oig_cloud/entities/data_sensor.py
+   - _get_local_entity_id_for_config() now searches BOTH format families for local fallback (primary domains and _cfg fallback).
+
+3. custom_components/oig_cloud/__init__.py
+   - _infer_box_id_from_local_entities() now matches BOTH:
+     * sensor.oig_local_<box_id>_
+     * sensor.<box_id>_(tbl_|proxy_control_)
+
+4. Tests updated/added:
+   - tests/test_proxy_normalization.py
+     * Added positive legacy format tests for sensor, switch, number, select
+     * Added cloud entity rejection test
+     * Updated missing-oig_local test to now accept legacy format
+   - tests/test_data_source_helpers.py
+     * Added iter_local_entities legacy discovery tests
+     * Added _infer_box_id_from_local_entities tests for current format, legacy format, ambiguous cases, and cloud entity rejection
+   - tests/test_data_sensor_more.py
+     * Added _get_local_entity_id_for_config legacy fallback tests (regular and _cfg suffix)
+   - tests/test_proxy_entity_contract.py
+     * Updated test_rejects_missing_oig_local_prefix to accept legacy format
+   - tests/test_init_setup_entry.py
+     * Updated test_infer_box_id_from_local_entities expectation to match actual behavior
+
+Test results:
+$ PYTHONPATH=/repos/oig-cloud .venv/bin/python -m pytest tests/ -q --tb=line
+================= 3390 passed, 27 skipped in 116.52s (0:01:56) =================
+
+All tests pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.27] - 2026-04-16
+
+### Fixed
+- Local proxy entity mapping now supports the legacy format without `oig_local_` prefix (e.g. `switch.2206237016_tbl_invertor_prms_to_grid_cfg`), fixing a regression for users with older proxy versions.
+- `normalize_proxy_entity_id`, `iter_local_entities`, `_get_local_entity_id_for_config`, and `_infer_box_id_from_local_entities` all recognize both `oig_local_` and legacy no-prefix formats.
+
 ## [2.3.26] - 2026-04-16
 
 ### Changed

--- a/custom_components/oig_cloud/__init__.py
+++ b/custom_components/oig_cloud/__init__.py
@@ -96,20 +96,31 @@ def _ensure_data_source_option_defaults(
 def _infer_box_id_from_local_entities(hass: HomeAssistant) -> str | None:
     """Best-effort inference of box_id from existing oig_local entity_ids.
 
-    Expected local entity_id pattern: sensor.oig_local_<box_id>_<suffix>
+    Expected local entity_id patterns:
+        sensor.oig_local_<box_id>_<suffix>  (current)
+        sensor.<box_id>_tbl_<suffix>         (legacy)
+        sensor.<box_id>_proxy_control_<suffix> (legacy)
     """
     try:
         from homeassistant.helpers import entity_registry as er
 
         reg = er.async_get(hass)
         ids: set[str] = set()
-        pat = re.compile(r"^sensor\\.oig_local_(\\d+)_")
+        pat = re.compile(r"^sensor\.oig_local_(\d+)_")
+        pat_legacy = re.compile(r"^sensor\.(\d+)_(?:tbl_|proxy_control_)")
         for ent in reg.entities.values():
             m = pat.match(ent.entity_id)
             if m:
                 ids.add(m.group(1))
+                continue
+            m = pat_legacy.match(ent.entity_id)
+            if m:
+                ids.add(m.group(1))
         if len(ids) == 1:
             return next(iter(ids))
+        return None
+    except Exception as err:
+        _LOGGER.debug("Failed to infer local box_id: %s", err, exc_info=True)
         return None
     except Exception as err:
         _LOGGER.debug("Failed to infer local box_id: %s", err, exc_info=True)

--- a/custom_components/oig_cloud/__init__.py
+++ b/custom_components/oig_cloud/__init__.py
@@ -122,9 +122,6 @@ def _infer_box_id_from_local_entities(hass: HomeAssistant) -> str | None:
     except Exception as err:
         _LOGGER.debug("Failed to infer local box_id: %s", err, exc_info=True)
         return None
-    except Exception as err:
-        _LOGGER.debug("Failed to infer local box_id: %s", err, exc_info=True)
-        return None
 
 
 def _get_planner_defaults() -> dict[str, Any]:

--- a/custom_components/oig_cloud/core/data_source.py
+++ b/custom_components/oig_cloud/core/data_source.py
@@ -556,7 +556,6 @@ class DataSourceController:
         if expected_box_id:
             if normalize_proxy_entity_id(entity_id, expected_box_id) is None:
                 return
-            event_box_id = expected_box_id
         else:
             # If box_id isn't configured yet, fall back to proxy-reported box_id (if available).
             proxy_box_id = _get_proxy_box_id(self.hass)
@@ -564,7 +563,6 @@ class DataSourceController:
                 return
             if normalize_proxy_entity_id(entity_id, proxy_box_id) is None:
                 return
-            event_box_id = proxy_box_id
 
         # Remember the latest local telemetry activity timestamp.
         try:
@@ -766,5 +764,3 @@ class DataSourceController:
                 self.hass.async_create_task(self.coordinator.async_request_refresh())
             except Exception as err:
                 _LOGGER.debug("Failed to schedule coordinator refresh: %s", err)
-
-

--- a/custom_components/oig_cloud/core/local_mapper.py
+++ b/custom_components/oig_cloud/core/local_mapper.py
@@ -76,11 +76,16 @@ def normalize_proxy_entity_id(
     if domain not in SUPPORTED_DOMAINS:
         return None
 
-    expected_prefix = f"{domain}.oig_local_{expected_device_id}_"
-    if not entity_id.startswith(expected_prefix):
+    for prefix in (
+        f"{domain}.oig_local_{expected_device_id}_",
+        f"{domain}.{expected_device_id}_",
+    ):
+        if entity_id.startswith(prefix):
+            raw_suffix = entity_id[len(prefix):]
+            break
+    else:
         return None
 
-    raw_suffix = entity_id[len(expected_prefix):]
     if not raw_suffix:
         return None
 
@@ -128,11 +133,8 @@ def normalize_proxy_entity_id(
 
 def iter_local_entities(hass: HomeAssistant, box_id: str):
     for domain in SUPPORTED_DOMAINS:
-        prefix = f"{domain}.oig_local_{box_id}_"
         for st in hass.states.async_all(domain):
-            if st.entity_id.startswith(prefix) and normalize_proxy_entity_id(
-                st.entity_id, box_id
-            ):
+            if normalize_proxy_entity_id(st.entity_id, box_id):
                 yield st
 
 

--- a/custom_components/oig_cloud/core/telemetry_store.py
+++ b/custom_components/oig_cloud/core/telemetry_store.py
@@ -10,9 +10,7 @@ from homeassistant.util import dt as dt_util
 
 from .local_mapper import (
     LocalUpdateApplier,
-    SUPPORTED_DOMAINS,
     iter_local_entities,
-    normalize_proxy_entity_id,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/oig_cloud/entities/data_sensor.py
+++ b/custom_components/oig_cloud/entities/data_sensor.py
@@ -592,20 +592,32 @@ class OigCloudDataSensor(_DataSensorBase):
                 primary_domains = []
             if not primary_domains:
                 primary_domains = list(SUPPORTED_DOMAINS)
-            for domain in primary_domains:
-                candidate = f"{domain}.oig_local_{self._box_id}_{suffix}"
-                if normalize_proxy_entity_id(candidate, self._box_id):
-                    state = self.hass.states.get(candidate)
-                    if state is not None:
-                        return candidate
+            for prefix_fmt in (
+                "{domain}.oig_local_{box_id}_{suffix}",
+                "{domain}.{box_id}_{suffix}",
+            ):
+                for domain in primary_domains:
+                    candidate = prefix_fmt.format(
+                        domain=domain, box_id=self._box_id, suffix=suffix
+                    )
+                    if normalize_proxy_entity_id(candidate, self._box_id):
+                        state = self.hass.states.get(candidate)
+                        if state is not None:
+                            return candidate
             # Fallback: proxy control entities append _cfg to the suffix.
             cfg_suffix = f"{suffix}_cfg"
-            for domain in SUPPORTED_DOMAINS:
-                candidate = f"{domain}.oig_local_{self._box_id}_{cfg_suffix}"
-                if normalize_proxy_entity_id(candidate, self._box_id):
-                    state = self.hass.states.get(candidate)
-                    if state is not None:
-                        return candidate
+            for prefix_fmt in (
+                "{domain}.oig_local_{box_id}_{suffix}",
+                "{domain}.{box_id}_{suffix}",
+            ):
+                for domain in SUPPORTED_DOMAINS:
+                    candidate = prefix_fmt.format(
+                        domain=domain, box_id=self._box_id, suffix=cfg_suffix
+                    )
+                    if normalize_proxy_entity_id(candidate, self._box_id):
+                        state = self.hass.states.get(candidate)
+                        if state is not None:
+                            return candidate
         return None
 
     def _coerce_number(self, value: Any) -> Any:

--- a/custom_components/oig_cloud/entities/data_sensor.py
+++ b/custom_components/oig_cloud/entities/data_sensor.py
@@ -574,6 +574,23 @@ class OigCloudDataSensor(_DataSensorBase):
             return _LANGS["on"][language]
         return _LANGS["unknown"][language]
 
+    def _find_local_entity_candidate(
+        self, suffix: str, domains: Tuple[str, ...]
+    ) -> Optional[str]:
+        for prefix_fmt in (
+            "{domain}.oig_local_{box_id}_{suffix}",
+            "{domain}.{box_id}_{suffix}",
+        ):
+            for domain in domains:
+                candidate = prefix_fmt.format(
+                    domain=domain, box_id=self._box_id, suffix=suffix
+                )
+                if normalize_proxy_entity_id(candidate, self._box_id):
+                    state = self.hass.states.get(candidate)
+                    if state is not None:
+                        return candidate
+        return None
+
     def _get_local_entity_id_for_config(
         self, sensor_config: Dict[str, Any]
     ) -> Optional[str]:
@@ -592,32 +609,19 @@ class OigCloudDataSensor(_DataSensorBase):
                 primary_domains = []
             if not primary_domains:
                 primary_domains = list(SUPPORTED_DOMAINS)
-            for prefix_fmt in (
-                "{domain}.oig_local_{box_id}_{suffix}",
-                "{domain}.{box_id}_{suffix}",
-            ):
-                for domain in primary_domains:
-                    candidate = prefix_fmt.format(
-                        domain=domain, box_id=self._box_id, suffix=suffix
-                    )
-                    if normalize_proxy_entity_id(candidate, self._box_id):
-                        state = self.hass.states.get(candidate)
-                        if state is not None:
-                            return candidate
+
+            candidate = self._find_local_entity_candidate(
+                suffix, tuple(primary_domains)
+            )
+            if candidate:
+                return candidate
+
             # Fallback: proxy control entities append _cfg to the suffix.
-            cfg_suffix = f"{suffix}_cfg"
-            for prefix_fmt in (
-                "{domain}.oig_local_{box_id}_{suffix}",
-                "{domain}.{box_id}_{suffix}",
-            ):
-                for domain in SUPPORTED_DOMAINS:
-                    candidate = prefix_fmt.format(
-                        domain=domain, box_id=self._box_id, suffix=cfg_suffix
-                    )
-                    if normalize_proxy_entity_id(candidate, self._box_id):
-                        state = self.hass.states.get(candidate)
-                        if state is not None:
-                            return candidate
+            cfg_candidate = self._find_local_entity_candidate(
+                f"{suffix}_cfg", SUPPORTED_DOMAINS
+            )
+            if cfg_candidate:
+                return cfg_candidate
         return None
 
     def _coerce_number(self, value: Any) -> Any:

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.26",
+  "version": "2.3.27",
   "zeroconf": []
 }

--- a/tests/test_data_sensor_more.py
+++ b/tests/test_data_sensor_more.py
@@ -85,6 +85,42 @@ def test_get_local_entity_id_for_config_prefers_existing_state(monkeypatch):
     )
 
 
+def test_get_local_entity_id_for_config_legacy_fallback(monkeypatch):
+    states = {
+        "switch.123_tbl_box_prms_mode": DummyState("1"),
+    }
+    sensor = _make_sensor(
+        monkeypatch,
+        "local_legacy",
+        {
+            "local_entity_suffix": "tbl_box_prms_mode",
+            "local_entity_domains": ["sensor", "switch"],
+        },
+        states=states,
+    )
+    assert sensor._get_local_entity_id_for_config(sensor._sensor_config) == (
+        "switch.123_tbl_box_prms_mode"
+    )
+
+
+def test_get_local_entity_id_for_config_legacy_cfg_fallback(monkeypatch):
+    states = {
+        "number.123_tbl_invertor_prms_bat_min_cfg": DummyState("10"),
+    }
+    sensor = _make_sensor(
+        monkeypatch,
+        "local_legacy_cfg",
+        {
+            "local_entity_suffix": "tbl_invertor_prms_bat_min",
+            "local_entity_domains": ["sensor"],
+        },
+        states=states,
+    )
+    assert sensor._get_local_entity_id_for_config(sensor._sensor_config) == (
+        "number.123_tbl_invertor_prms_bat_min_cfg"
+    )
+
+
 def test_get_local_entity_id_for_config_default_domain(monkeypatch):
     states = {"sensor.oig_local_123_tbl_actual_aci_wr": DummyState("1")}
     sensor = _make_sensor(

--- a/tests/test_data_source_helpers.py
+++ b/tests/test_data_source_helpers.py
@@ -7,6 +7,7 @@ import pytest
 
 from custom_components.oig_cloud.core import data_source as module
 from custom_components.oig_cloud.core.local_mapper import iter_local_entities
+from custom_components.oig_cloud import _infer_box_id_from_local_entities
 
 
 class DummyState:
@@ -213,3 +214,120 @@ def test_iter_local_entities_rejects_malformed_ids():
     assert "sensor.oig_local_123_" not in found
     assert "sensor.oig_local_123_bad" not in found
     assert "sensor.oig_local_123_cfg" not in found
+
+
+def test_iter_local_entities_discovers_legacy_format():
+    now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    states = [
+        DummyState("sensor.2206237016_tbl_actual_aci_wr", "1", last_updated=now),
+        DummyState("switch.2206237016_tbl_invertor_prms_to_grid_cfg", "on", last_updated=now),
+        DummyState("number.2206237016_tbl_batt_prms_bat_min_cfg", "10", last_updated=now),
+        DummyState("select.2206237016_proxy_control_proxy_mode_cfg", "auto", last_updated=now),
+        DummyState("sensor.9999_tbl_actual_aci_wr", "1", last_updated=now),
+    ]
+    hass = DummyHass(states)
+    found = [st.entity_id for st in iter_local_entities(hass, "2206237016")]
+    assert "sensor.2206237016_tbl_actual_aci_wr" in found
+    assert "switch.2206237016_tbl_invertor_prms_to_grid_cfg" in found
+    assert "number.2206237016_tbl_batt_prms_bat_min_cfg" in found
+    assert "select.2206237016_proxy_control_proxy_mode_cfg" in found
+    assert "sensor.9999_tbl_actual_aci_wr" not in found
+
+
+def test_iter_local_entities_mixed_current_and_legacy():
+    now = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    states = [
+        DummyState("sensor.oig_local_2206237016_tbl_actual_aci_wr", "1", last_updated=now),
+        DummyState("switch.2206237016_tbl_invertor_prms_to_grid_cfg", "on", last_updated=now),
+    ]
+    hass = DummyHass(states)
+    found = [st.entity_id for st in iter_local_entities(hass, "2206237016")]
+    assert "sensor.oig_local_2206237016_tbl_actual_aci_wr" in found
+    assert "switch.2206237016_tbl_invertor_prms_to_grid_cfg" in found
+
+
+def test_infer_box_id_from_current_local_entities(monkeypatch):
+    class DummyEnt:
+        def __init__(self, entity_id):
+            self.entity_id = entity_id
+
+    class DummyReg:
+        def __init__(self, entities):
+            self.entities = entities
+
+    hass = DummyHass()
+    hass.data = {}
+    reg = DummyReg({
+        "a": DummyEnt("sensor.oig_local_2206237016_tbl_actual_aci_wr"),
+        "b": DummyEnt("switch.oig_local_2206237016_tbl_invertor_prms_to_grid_cfg"),
+    })
+    monkeypatch.setattr(
+        "homeassistant.helpers.entity_registry.async_get",
+        lambda _hass: reg,
+    )
+    assert _infer_box_id_from_local_entities(hass) == "2206237016"
+
+
+def test_infer_box_id_from_legacy_local_entities(monkeypatch):
+    class DummyEnt:
+        def __init__(self, entity_id):
+            self.entity_id = entity_id
+
+    class DummyReg:
+        def __init__(self, entities):
+            self.entities = entities
+
+    hass = DummyHass()
+    hass.data = {}
+    reg = DummyReg({
+        "a": DummyEnt("sensor.2206237016_tbl_actual_aci_wr"),
+        "b": DummyEnt("switch.2206237016_proxy_control_proxy_mode_cfg"),
+    })
+    monkeypatch.setattr(
+        "homeassistant.helpers.entity_registry.async_get",
+        lambda _hass: reg,
+    )
+    assert _infer_box_id_from_local_entities(hass) == "2206237016"
+
+
+def test_infer_box_id_returns_none_when_ambiguous(monkeypatch):
+    class DummyEnt:
+        def __init__(self, entity_id):
+            self.entity_id = entity_id
+
+    class DummyReg:
+        def __init__(self, entities):
+            self.entities = entities
+
+    hass = DummyHass()
+    hass.data = {}
+    reg = DummyReg({
+        "a": DummyEnt("sensor.oig_local_2206237016_tbl_actual_aci_wr"),
+        "b": DummyEnt("sensor.oig_local_9999999999_tbl_actual_aci_wr"),
+    })
+    monkeypatch.setattr(
+        "homeassistant.helpers.entity_registry.async_get",
+        lambda _hass: reg,
+    )
+    assert _infer_box_id_from_local_entities(hass) is None
+
+
+def test_infer_box_id_ignores_cloud_entities(monkeypatch):
+    class DummyEnt:
+        def __init__(self, entity_id):
+            self.entity_id = entity_id
+
+    class DummyReg:
+        def __init__(self, entities):
+            self.entities = entities
+
+    hass = DummyHass()
+    hass.data = {}
+    reg = DummyReg({
+        "a": DummyEnt("sensor.oig_2206237016_invertor_prms_to_grid"),
+    })
+    monkeypatch.setattr(
+        "homeassistant.helpers.entity_registry.async_get",
+        lambda _hass: reg,
+    )
+    assert _infer_box_id_from_local_entities(hass) is None

--- a/tests/test_init_setup_entry.py
+++ b/tests/test_init_setup_entry.py
@@ -840,7 +840,7 @@ def test_infer_box_id_from_local_entities(monkeypatch):
 
     hass = DummyHass()
 
-    assert init_module._infer_box_id_from_local_entities(hass) is None
+    assert init_module._infer_box_id_from_local_entities(hass) == "789"
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_entity_contract.py
+++ b/tests/test_proxy_entity_contract.py
@@ -122,10 +122,13 @@ class TestNormalizeProxyEntityIdContract:
         result = normalize_proxy_entity_id(entity_id, "2206237016")
         assert result is None
 
-    def test_rejects_missing_oig_local_prefix(self):
+    def test_accepts_legacy_format_without_oig_local_prefix(self):
         entity_id = "switch.2206237016_tbl_invertor_prms_to_grid_cfg"
         result = normalize_proxy_entity_id(entity_id, "2206237016")
-        assert result is None
+        assert result is not None
+        assert result.domain == "switch"
+        assert result.raw_suffix == "tbl_invertor_prms_to_grid_cfg"
+        assert result.is_control is True
 
     def test_rejects_unsupported_domain_even_with_correct_prefix(self):
         entity_id = "light.oig_local_2206237016_tbl_box_prms_mode"

--- a/tests/test_proxy_normalization.py
+++ b/tests/test_proxy_normalization.py
@@ -229,19 +229,86 @@ class TestNormalizeProxyEntityId:
         assert result is None
 
     # ------------------------------------------------------------------
-    # Negative: missing oig_local_ prefix
+    # Positive: legacy format without oig_local_ prefix
     # ------------------------------------------------------------------
 
-    def test_rejects_missing_oig_local_prefix(self):
-        result = normalize_proxy_entity_id(
+    def test_legacy_sensor_numeric_device_id(self):
+        desc = normalize_proxy_entity_id(
+            "sensor.2206237016_tbl_actual_aci_wr",
+            "2206237016",
+        )
+        assert desc is not None
+        assert desc.domain == "sensor"
+        assert desc.device_id == "2206237016"
+        assert desc.table == "tbl_actual_aci"
+        assert desc.key == "wr"
+        assert desc.is_control is False
+        assert desc.raw_suffix == "tbl_actual_aci_wr"
+
+    def test_legacy_switch_control_cfg(self):
+        desc = normalize_proxy_entity_id(
             "switch.2206237016_tbl_invertor_prms_to_grid_cfg",
+            "2206237016",
+        )
+        assert desc is not None
+        assert desc.domain == "switch"
+        assert desc.device_id == "2206237016"
+        assert desc.table == "tbl_invertor_prms"
+        assert desc.key == "to_grid"
+        assert desc.is_control is True
+        assert desc.raw_suffix == "tbl_invertor_prms_to_grid_cfg"
+
+    def test_legacy_number_control_cfg(self):
+        desc = normalize_proxy_entity_id(
+            "number.2206237016_tbl_batt_prms_bat_min_cfg",
+            "2206237016",
+        )
+        assert desc is not None
+        assert desc.domain == "number"
+        assert desc.device_id == "2206237016"
+        assert desc.table == "tbl_batt_prms"
+        assert desc.key == "bat_min"
+        assert desc.is_control is True
+        assert desc.raw_suffix == "tbl_batt_prms_bat_min_cfg"
+
+    def test_legacy_select_proxy_control_cfg(self):
+        desc = normalize_proxy_entity_id(
+            "select.2206237016_proxy_control_proxy_mode_cfg",
+            "2206237016",
+        )
+        assert desc is not None
+        assert desc.domain == "select"
+        assert desc.device_id == "2206237016"
+        assert desc.table == "proxy_control"
+        assert desc.key == "proxy_mode"
+        assert desc.is_control is True
+        assert desc.raw_suffix == "proxy_control_proxy_mode_cfg"
+
+    # ------------------------------------------------------------------
+    # Negative: cloud entity must NOT match local format
+    # ------------------------------------------------------------------
+
+    def test_rejects_cloud_entity_id(self):
+        result = normalize_proxy_entity_id(
+            "sensor.oig_2206237016_invertor_prms_to_grid",
             "2206237016",
         )
         assert result is None
 
-    def test_rejects_missing_oig_local_prefix_number(self):
+    # ------------------------------------------------------------------
+    # Negative: missing oig_local_ prefix (legacy tlb_ is still rejected)
+    # ------------------------------------------------------------------
+
+    def test_rejects_legacy_tlb_prefix_switch_no_oig_local(self):
         result = normalize_proxy_entity_id(
-            "number.2206237016_tbl_batt_prms_bat_min_cfg",
+            "switch.2206237016_tlb_invertor_prms_to_grid_cfg",
+            "2206237016",
+        )
+        assert result is None
+
+    def test_rejects_legacy_tlb_prefix_sensor_no_oig_local(self):
+        result = normalize_proxy_entity_id(
+            "sensor.2206237016_tlb_actual_aci_wr",
             "2206237016",
         )
         assert result is None


### PR DESCRIPTION
## Summary
Hotfix for users with older OIG Proxy versions that generate local entities without the `oig_local_` prefix (e.g. `switch.2206237016_tbl_invertor_prms_to_grid_cfg`).

## Changes
- `normalize_proxy_entity_id` now accepts both `oig_local_` and legacy no-prefix formats.
- `iter_local_entities` discovers legacy proxy entities correctly.
- `data_sensor.py` local helper falls back to legacy entity IDs.
- `_infer_box_id_from_local_entities` infers box_id from legacy patterns.

## Verification
- Full test suite: **3390 passed, 27 skipped**