### PR TITLE
fix: correct grid-delivery state in local_only mode for crcte-based inverters (v2.3.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.28] - 2026-04-16
+
+### Fixed
+- `sensor.oig_{box_id}_invertor_prms_to_grid` now correctly reflects grid-delivery state in `local_only` mode for inverters that expose `box_prms.crcte` instead of `box_prms.crct`.
+- Added `box_prms_crcte` sensor type so the local-mapper suffix table includes the `crcte` key and payload updates are applied correctly.
+- `_get_local_grid_mode()` now reads both `box_prms_crcte` and `box_prms_crct` and prefers `crcte` when available, matching the resolver's preference order.
+- `_on_any_state_change()` no longer silently drops legacy proxy entity events (format `{domain}.{device_id}_tbl_…`) — it now delegates all filtering to `normalize_proxy_entity_id()`, which accepts both the current `oig_local_` prefix and the legacy format.
+- `box_prms_crcte` entity now shows translated On/Off labels instead of raw `0`/`1`.
+
 ## [2.3.27] - 2026-04-16
 
 ### Fixed

--- a/custom_components/oig_cloud/core/data_source.py
+++ b/custom_components/oig_cloud/core/data_source.py
@@ -15,7 +15,6 @@ from homeassistant.util import dt as dt_util
 
 from ..const import DOMAIN
 from .local_mapper import (
-    SUPPORTED_DOMAINS,
     iter_local_entities,
     normalize_proxy_entity_id,
 )

--- a/custom_components/oig_cloud/core/data_source.py
+++ b/custom_components/oig_cloud/core/data_source.py
@@ -546,13 +546,11 @@ class DataSourceController:
         entity_id = event.data.get("entity_id")
         if not isinstance(entity_id, str):
             return
-        if not any(
-            entity_id.startswith(f"{domain}.oig_local_") for domain in SUPPORTED_DOMAINS
-        ):
-            return
 
         expected_box_id = _get_expected_box_id(self.entry)
 
+        # Use normalize_proxy_entity_id as the sole gate — it handles both the
+        # current "oig_local_" prefix and the legacy "<device_id>_" format.
         if expected_box_id:
             if normalize_proxy_entity_id(entity_id, expected_box_id) is None:
                 return

--- a/custom_components/oig_cloud/entities/data_sensor.py
+++ b/custom_components/oig_cloud/entities/data_sensor.py
@@ -317,7 +317,7 @@ class OigCloudDataSensor(_DataSensorBase):
             return self._get_ssrmode_name(raw_value, "cs")
         if self._sensor_type == "boiler_manual_mode":
             return self._get_boiler_mode_name(raw_value, "cs")
-        if self._sensor_type in {"boiler_is_use", "box_prms_crct"}:
+        if self._sensor_type in {"boiler_is_use", "box_prms_crct", "box_prms_crcte"}:
             return self._get_on_off_name(raw_value, "cs")
         return _STATE_NOT_HANDLED
 
@@ -680,15 +680,20 @@ class OigCloudDataSensor(_DataSensorBase):
 
     def _get_local_grid_mode(self, node_value: Any, language: str) -> str:
         try:
-            grid_enabled_raw = self._get_local_value_for_sensor_type(
-                "box_prms_crct"
-            )
+            grid_enabled_crcte = self._get_local_value_for_sensor_type("box_prms_crcte")
+            grid_enabled_crct = self._get_local_value_for_sensor_type("box_prms_crct")
             max_grid_feed_raw = self._get_local_value_for_sensor_type(
                 "invertor_prm1_p_max_feed_grid"
             )
 
+            box_prms: dict = {}
+            if grid_enabled_crcte is not None:
+                box_prms["crcte"] = grid_enabled_crcte
+            if grid_enabled_crct is not None:
+                box_prms["crct"] = grid_enabled_crct
+
             raw_values = {
-                "box_prms": {"crct": grid_enabled_raw},
+                "box_prms": box_prms,
                 "invertor_prm1": {"p_max_feed_grid": max_grid_feed_raw},
                 "invertor_prms": {"to_grid": node_value},
             }

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.27",
+  "version": "2.3.28",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/sensors/SENSOR_TYPES_MISC.py
+++ b/custom_components/oig_cloud/sensors/SENSOR_TYPES_MISC.py
@@ -97,6 +97,20 @@ SENSOR_TYPES_MISC: Dict[str, Dict[str, Any]] = {
         "device_mapping": "main",
         "local_entity_suffix": "tbl_box_prms_crct",
     },
+    "box_prms_crcte": {
+        "name": "Distribution Emergency Control Extended",
+        "name_cs": "Krizové ovládání distribuce (rozšířené)",
+        "device_class": SensorDeviceClass.ENUM,
+        "unit_of_measurement": None,
+        "state_class": None,
+        "node_id": "box_prms",
+        "node_key": "crcte",
+        "entity_category": EntityCategory.DIAGNOSTIC,
+        "options": ["Vypnuto / Off", "Zapnuto / On"],
+        "sensor_type_category": "data",
+        "device_mapping": "main",
+        "local_entity_suffix": "tbl_box_prms_crcte",
+    },
     # Notification sensors - nová kategorie
     "latest_notification": {
         "name": "Latest Notification",

--- a/tests/test_data_source_controller.py
+++ b/tests/test_data_source_controller.py
@@ -1227,3 +1227,35 @@ def test_on_any_state_change_tracks_control_domains(entity_id):
     assert entity_id in controller._pending_local_entities
     assert controller._last_local_entity_update is not None
 
+
+def test_on_any_state_change_tracks_legacy_local_entity_id():
+    now = dt_util.utcnow()
+    states = [
+        DummyState(module.PROXY_LAST_DATA_ENTITY_ID, now.isoformat(), last_updated=now),
+        DummyState(module.PROXY_BOX_ID_ENTITY_ID, "2206237016", last_updated=now),
+    ]
+    hass = DummyHass(states)
+    entry = _make_entry(module.DATA_SOURCE_LOCAL_ONLY, box_id="2206237016")
+    controller = module.DataSourceController(hass, entry, coordinator=None)
+    controller._schedule_debounced_poke = lambda: None
+
+    hass.data[module.DOMAIN][entry.entry_id] = {
+        "data_source_state": module.DataSourceState(
+            configured_mode=module.DATA_SOURCE_LOCAL_ONLY,
+            effective_mode=module.DATA_SOURCE_LOCAL_ONLY,
+            local_available=True,
+            last_local_data=now,
+            reason="local_ok",
+        )
+    }
+
+    legacy_entity_id = "switch.2206237016_tbl_invertor_prms_to_grid_cfg"
+    event = SimpleNamespace(
+        data={"entity_id": legacy_entity_id},
+        time_fired=now + timedelta(seconds=5),
+    )
+    controller._on_any_state_change(event)
+
+    assert legacy_entity_id in controller._pending_local_entities
+    assert controller._last_local_entity_update is not None
+

--- a/tests/test_entities_data_sensor_more3.py
+++ b/tests/test_entities_data_sensor_more3.py
@@ -370,3 +370,42 @@ def test_get_node_value_exception():
     sensor = _make_sensor("box_prms_mode", coordinator)
     sensor._sensor_config = {"node_id": "node", "node_key": []}
     assert sensor.get_node_value() is None
+
+
+def test_get_local_grid_mode_crcte_only(monkeypatch):
+    from custom_components.oig_cloud.entities.data_sensor import GridMode
+
+    sensor = _make_sensor("invertor_prms_to_grid")
+    values = {
+        "box_prms_crcte": 1,
+        "box_prms_crct": None,
+        "invertor_prm1_p_max_feed_grid": 15000,
+    }
+    monkeypatch.setattr(sensor, "_get_local_value_for_sensor_type", lambda k: values.get(k))
+    assert sensor._get_local_grid_mode(1, "cs") == GridMode.ON
+
+
+def test_get_local_grid_mode_crcte_overrides_crct(monkeypatch):
+    from custom_components.oig_cloud.entities.data_sensor import GridMode
+
+    sensor = _make_sensor("invertor_prms_to_grid")
+    values = {
+        "box_prms_crcte": 1,
+        "box_prms_crct": 0,
+        "invertor_prm1_p_max_feed_grid": 15000,
+    }
+    monkeypatch.setattr(sensor, "_get_local_value_for_sensor_type", lambda k: values.get(k))
+    assert sensor._get_local_grid_mode(1, "cs") == GridMode.ON
+
+
+def test_get_local_grid_mode_crct_fallback(monkeypatch):
+    from custom_components.oig_cloud.entities.data_sensor import GridMode
+
+    sensor = _make_sensor("invertor_prms_to_grid")
+    values = {
+        "box_prms_crcte": None,
+        "box_prms_crct": 1,
+        "invertor_prm1_p_max_feed_grid": 15000,
+    }
+    monkeypatch.setattr(sensor, "_get_local_value_for_sensor_type", lambda k: values.get(k))
+    assert sensor._get_local_grid_mode(1, "cs") == GridMode.ON


### PR DESCRIPTION
## Summary

- **Bug**: `sensor.oig_{box_id}_invertor_prms_to_grid` reported wrong state (\"Vypnuto\") in `local_only` mode on newer firmware that uses `box_prms.crcte` instead of `box_prms.crct`.
- Three distinct root causes, all fixed in this PR.

## Changes

### Fix 1 — `data_source.py`: legacy entity events silently dropped
`_on_any_state_change()` used a `startswith("oig_local_")` pre-filter that discarded events from legacy proxy entities (e.g. `switch.2206237016_tbl_invertor_prms_to_grid_cfg`). Replaced with a single `normalize_proxy_entity_id()` call that handles both current and legacy formats.

### Fix 2 — `SENSOR_TYPES_MISC.py`: missing `box_prms_crcte` suffix entry
`_build_suffix_updates()` had no entry for `crcte`, so the coordinator payload was never updated from the local entity. Added `box_prms_crcte` sensor type with `local_entity_suffix: "tbl_box_prms_crcte"`. Also added it to `_get_special_state()` so the entity shows On/Off labels instead of raw `0`/`1`.

### Fix 3 — `data_sensor.py`: `_get_local_grid_mode()` ignored `crcte`
The fallback path only read `box_prms_crct`. Rewrote to read both fields and populate `box_prms` dict with non-None values only, so `resolve_grid_delivery_live_state()` correctly prefers `crcte` over `crct`.

## Tests

Four new regression tests added. Full suite: 3420 passed.