### PR TITLE
fix(shield): resolve boiler confirmation target by device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.31] - 2026-04-18
+
+### Fixed
+- ServiceShield boiler confirmation now resolves the target `boiler_manual_mode` entity from the service call `device_id`, preventing false pending and timeout states when a different box is selected than the config entry default.
+- Added regression coverage for boiler-mode Shield verification against the requested target box.
+
 ## [2.3.30] - 2026-04-16
 
 ### Changed

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.30",
+  "version": "2.3.31",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/shield/validation.py
+++ b/custom_components/oig_cloud/shield/validation.py
@@ -117,7 +117,7 @@ def extract_expected_entities(
 
     def find_entity(suffix: str) -> str | None:
         _LOGGER.info("[FIND ENTITY] Hledám cloud entitu se suffixem: %s", suffix)
-        box_id = _resolve_box_id_for_shield(shield)
+        box_id = _resolve_target_box_id(shield, data, service_name)
         if not box_id:
             _LOGGER.warning(
                 "[FIND ENTITY] box_id nelze určit, cloud entitu pro suffix '%s' nelze vybrat",
@@ -149,6 +149,38 @@ def extract_expected_entities(
         return _expected_grid_delivery(shield, data, find_entity)
 
     return {}
+
+
+def _resolve_target_box_id(
+    shield: Any, data: Dict[str, Any], service_name: str
+) -> Optional[str]:
+    device_id = data.get("device_id")
+    if not device_id:
+        return _resolve_box_id_for_shield(shield)
+
+    entry_id = getattr(shield.entry, "entry_id", None)
+    if not isinstance(entry_id, str) or not entry_id:
+        return _resolve_box_id_for_shield(shield)
+
+    try:
+        from ..services import get_box_id_from_device
+
+        box_id = get_box_id_from_device(shield.hass, device_id, entry_id)
+        if box_id:
+            _LOGGER.debug(
+                "[FIND ENTITY] Resolved target box_id %s from device_id for %s",
+                box_id,
+                service_name,
+            )
+            return box_id
+    except Exception:
+        _LOGGER.debug(
+            "[FIND ENTITY] Failed to resolve target box_id from service data for %s",
+            service_name,
+            exc_info=True,
+        )
+
+    return _resolve_box_id_for_shield(shield)
 
 
 def _expected_formating_mode() -> Dict[str, str]:

--- a/tests/test_shield_validation_more3.py
+++ b/tests/test_shield_validation_more3.py
@@ -24,15 +24,29 @@ class DummyHass:
 
 
 class DummyEntry:
-    def __init__(self, options=None, data=None):
+    def __init__(self, options=None, data=None, entry_id="entry"):
         self.options = options or {}
         self.data = data or {}
+        self.entry_id = entry_id
 
 
 class DummyEntity:
     def __init__(self, entity_id, state):
         self.entity_id = entity_id
         self.state = state
+
+
+class DummyDevice:
+    def __init__(self, identifiers):
+        self.identifiers = identifiers
+
+
+class DummyDeviceRegistry:
+    def __init__(self, device=None):
+        self._device = device
+
+    def async_get(self, _device_id):
+        return self._device
 
 
 class DummyShield:
@@ -115,6 +129,60 @@ def test_extract_expected_entities_boiler_mode_same():
         shield, "oig_cloud.set_boiler_mode", {"mode": "Manual"}
     )
     assert expected == {}
+
+
+def test_extract_expected_entities_boiler_mode_uses_service_device_id(monkeypatch):
+    entities = [
+        DummyEntity("sensor.oig_123_boiler_manual_mode", "CBB"),
+        DummyEntity("sensor.oig_456_boiler_manual_mode", "Manuální"),
+    ]
+    hass = DummyHass(entities)
+    entry = DummyEntry(options={"box_id": "123"}, entry_id="entry")
+    shield = DummyShield(hass, entry)
+    hass.data = {"oig_cloud": {entry.entry_id: {"coordinator": SimpleNamespace(data={})}}}
+    device_registry = DummyDeviceRegistry(DummyDevice({("oig_cloud", "456_shield")}))
+
+    monkeypatch.setattr(
+        "homeassistant.helpers.device_registry.async_get",
+        lambda _hass: device_registry,
+    )
+
+    expected = module.extract_expected_entities(
+        shield,
+        "oig_cloud.set_boiler_mode",
+        {"mode": "Manual", "device_id": "device-id"},
+    )
+
+    assert expected == {}
+    assert shield.last_checked_entity_id == "sensor.oig_456_boiler_manual_mode"
+
+
+def test_extract_expected_entities_boiler_mode_targets_service_box_when_change_needed(
+    monkeypatch,
+):
+    entities = [
+        DummyEntity("sensor.oig_123_boiler_manual_mode", "Manuální"),
+        DummyEntity("sensor.oig_456_boiler_manual_mode", "CBB"),
+    ]
+    hass = DummyHass(entities)
+    entry = DummyEntry(options={"box_id": "123"}, entry_id="entry")
+    shield = DummyShield(hass, entry)
+    hass.data = {"oig_cloud": {entry.entry_id: {"coordinator": SimpleNamespace(data={})}}}
+    device_registry = DummyDeviceRegistry(DummyDevice({("oig_cloud", "456_shield")}))
+
+    monkeypatch.setattr(
+        "homeassistant.helpers.device_registry.async_get",
+        lambda _hass: device_registry,
+    )
+
+    expected = module.extract_expected_entities(
+        shield,
+        "oig_cloud.set_boiler_mode",
+        {"mode": "Manual", "device_id": "device-id"},
+    )
+
+    assert expected == {"sensor.oig_456_boiler_manual_mode": "Manuální"}
+    assert shield.last_checked_entity_id == "sensor.oig_456_boiler_manual_mode"
 
 
 def test_extract_expected_entities_grid_limit_bad_state():


### PR DESCRIPTION
## Summary
- resolve ServiceShield boiler confirmation against the service call target box instead of always using the entry/coordinator default box
- add multi-device regression coverage for `set_boiler_mode` so Shield watches the correct `sensor.oig_<box>_boiler_manual_mode`
- bump version to 2.3.31 and add changelog notes for the fix

## Verification
- `pytest tests/test_shield_validation_more3.py -k \"boiler_mode_uses_service_device_id or boiler_mode_targets_service_box_when_change_needed\" -v`
- `pytest tests -v` → 3396 passed, 27 skipped