### PR TITLE
fix(battery): restore grid charging before delayed solar refill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.34] - 2026-04-20
+
+### Fixed
+- Hybrid battery planning no longer suppresses grid charging just because later daytime solar can eventually refill the battery; hold-limit protection now still tops the battery up before delayed solar arrives.
+- `_force_target_before_index()` now evaluates reachability only within the enforced window, preventing future solar outside that window from disabling the low-SOC recovery path.
+- Added regression coverage for the delayed-solar / low-SOC hold scenario so the planner cannot leave the battery sitting near `hw_min` for too long without scheduling grid charge.
+
 ## [2.3.33] - 2026-04-19
 
 ### Added

--- a/custom_components/oig_cloud/battery_forecast/strategy/hybrid_planning.py
+++ b/custom_components/oig_cloud/battery_forecast/strategy/hybrid_planning.py
@@ -176,7 +176,7 @@ def plan_charging_intervals(
         ):
             infeasible_reason = None
 
-        if _pre_economic_max_soc < _target_effective - eps_kwh and _apply_hw_min_hold_limit(
+        if _apply_hw_min_hold_limit(
             strategy,
             initial_battery_kwh=initial_battery_kwh,
             solar_forecast=solar_forecast,
@@ -1401,7 +1401,12 @@ def _force_target_before_index(
             consumption_forecast=consumption_forecast,
             charging_intervals=charging_intervals,
         )
-        max_soc = max(battery_trajectory) if battery_trajectory else initial_battery_kwh
+        limit_idx = max(0, min(limit, len(battery_trajectory)))
+        max_soc = (
+            max([initial_battery_kwh, *battery_trajectory[:limit_idx]])
+            if battery_trajectory and limit_idx > 0
+            else initial_battery_kwh
+        )
         if max_soc >= strategy._target - eps_kwh:
             break
         candidate = _find_cheapest_candidate(

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0"],
   "ssdp": [],
-  "version": "2.3.33",
+  "version": "2.3.34",
   "zeroconf": []
 }

--- a/tests/test_hybrid_economic_charging_solar_overflow.py
+++ b/tests/test_hybrid_economic_charging_solar_overflow.py
@@ -58,10 +58,12 @@ class DummyConfig:
     negative_price_strategy = NegativePriceStrategy.CHARGE_GRID
     round_trip_efficiency = 0.9
     price_hysteresis_czk = 0.0
+    hw_min_hold_hours = 0.0
 
 
 class DummySimConfig:
     ac_dc_efficiency = 0.9
+    min_capacity_kwh = 0.0
 
 
 class DummyStrategy:
@@ -357,4 +359,55 @@ def test_cloudy_fallback_does_not_trust_optimistic_solar():
         f"Cloudy fallback regression failed: Expected protective charging under cloudy conditions "
         f"but got no ADD decisions. Charging intervals: {charging_intervals}. "
         f"Planner must add protective charging when solar is insufficient."
+    )
+
+
+def test_future_solar_fill_does_not_skip_hw_min_hold_protection():
+    strategy = DummyStrategy()
+    strategy._planning_min = 0.5
+    strategy._target = 3.0
+    strategy.config.hw_min_hold_hours = 0.5
+    strategy.sim_config.min_capacity_kwh = 2.0
+
+    initial_battery_kwh = 2.2
+    prices = [0.3] * 12
+    solar_forecast = [0.0] * 6 + [0.9] * 6
+    consumption_forecast = [0.2] * 12
+
+    charging_intervals, _, _ = module.plan_charging_intervals(
+        strategy,
+        initial_battery_kwh=initial_battery_kwh,
+        solar_forecast=solar_forecast,
+        consumption_forecast=consumption_forecast,
+        prices=prices,
+        balancing_plan=None,
+        negative_price_intervals=None,
+    )
+
+    trajectory = module.simulate_trajectory(
+        strategy,
+        initial_battery_kwh=initial_battery_kwh,
+        solar_forecast=solar_forecast,
+        consumption_forecast=consumption_forecast,
+        charging_intervals=charging_intervals,
+    )
+
+    max_hold_streak = 0
+    current_hold_streak = 0
+    for soc in trajectory:
+        if soc <= strategy.sim_config.min_capacity_kwh + 1e-6:
+            current_hold_streak += 1
+            max_hold_streak = max(max_hold_streak, current_hold_streak)
+        else:
+            current_hold_streak = 0
+
+    assert charging_intervals, (
+        "Planner must add grid charging before delayed solar arrives when battery would otherwise sit at or below hw_min for too long."
+    )
+    assert any(idx < 6 for idx in charging_intervals), (
+        f"Expected at least one pre-solar charging interval before index 6, got {sorted(charging_intervals)}."
+    )
+    assert max_hold_streak <= 2, (
+        f"Battery stayed at or below hw_min for {max_hold_streak} consecutive intervals despite hw_min_hold_hours=0.5. "
+        f"Trajectory: {trajectory}"
     )


### PR DESCRIPTION
## Summary
- restore hybrid battery planner charging when the battery would otherwise sit at `hw_min` too long before later solar refills it
- limit `_force_target_before_index()` reachability checks to the enforced window so future solar outside that window cannot disable low-SOC recovery
- bump the integration to 2.3.34 and document the fix in the changelog

## Verification
- `.venv/bin/python -m flake8 custom_components/oig_cloud tests --max-line-length=120`
- `.venv/bin/mypy custom_components/oig_cloud --ignore-missing-imports --explicit-package-bases`
- `.venv/bin/pytest -v --tb=short --cov=custom_components/oig_cloud --cov-report=xml --cov-report=term-missing:skip-covered`
- `npm test`