### PR TITLE
Fix load profiles and repeated startup history scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2026-08-13
+
+### Fixed
+- Battery forecast load profiles now resolve both box-prefixed and canonical
+  `sensor.load_avg_*` entity IDs, restoring the ten configured household load
+  buckets instead of silently falling back to a fixed load.
+- Battery health analysis now persists successful scans even when no new clean
+  charging cycle is found and skips a duplicate full recorder scan for 20 hours,
+  avoiding repeated high-volume history reads after Home Assistant restarts.
+
 ## [2.4.0] - 2026-07-31
 
 Major user-facing release. Full Czech release notes: `RELEASE_NOTES_v2.4.0.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Battery health analysis now persists successful scans even when no new clean
   charging cycle is found and skips a duplicate full recorder scan for 20 hours,
   avoiding repeated high-volume history reads after Home Assistant restarts.
+- The boiler daily Wh counter now advertises the Home Assistant energy device
+  class, preserving valid utility-meter metadata, and an expected empty forecast
+  during startup is logged as debug instead of a warning.
 
 ## [2.4.0] - 2026-07-31
 

--- a/custom_components/oig_cloud/battery_forecast/data/load_profiles.py
+++ b/custom_components/oig_cloud/battery_forecast/data/load_profiles.py
@@ -24,27 +24,38 @@ def get_load_avg_sensors(sensor: Any) -> Dict[str, Any]:
         if "time_range" not in config or "day_type" not in config:
             continue
 
-        entity_id = f"sensor.oig_{sensor._box_id}_{sensor_type}"
-        state = sensor._hass.states.get(entity_id)
-        if not state:
-            _LOGGER.debug("Sensor %s not found in HA", entity_id)
-            continue
+        candidate_ids = (
+            f"sensor.oig_{sensor._box_id}_{sensor_type}",
+            f"sensor.{sensor_type}",
+        )
+        for entity_id in candidate_ids:
+            state = sensor._hass.states.get(entity_id)
+            if not state:
+                _LOGGER.debug("Sensor %s not found in HA", entity_id)
+                continue
 
-        if state.state in ["unknown", "unavailable"]:
-            _LOGGER.debug("Sensor %s is %s", entity_id, state.state)
-            continue
+            if state.state in ["unknown", "unavailable"]:
+                _LOGGER.debug("Sensor %s is %s", entity_id, state.state)
+                continue
 
-        try:
-            value = float(state.state)
-        except (ValueError, TypeError) as err:
-            _LOGGER.warning("[OIG_CLOUD_WARNING][component=planner][corr=na][run=na] " + "Failed to parse %s value '%s': %s", entity_id, state.state, err)
-            continue
+            try:
+                value = float(state.state)
+            except (ValueError, TypeError) as err:
+                _LOGGER.warning(
+                    "[OIG_CLOUD_WARNING][component=planner][corr=na][run=na] "
+                    "Failed to parse %s value '%s': %s",
+                    entity_id,
+                    state.state,
+                    err,
+                )
+                continue
 
-        load_sensors[entity_id] = {
-            "value": value,
-            "time_range": config["time_range"],
-            "day_type": config["day_type"],
-        }
+            load_sensors[entity_id] = {
+                "value": value,
+                "time_range": config["time_range"],
+                "day_type": config["day_type"],
+            }
+            break
 
     _LOGGER.info("Found %s valid load_avg sensors", len(load_sensors))
     if load_sensors:

--- a/custom_components/oig_cloud/core/coordinator.py
+++ b/custom_components/oig_cloud/core/coordinator.py
@@ -1005,7 +1005,7 @@ class OigCloudCoordinator(DataUpdateCoordinator):
             forecast_payload = self._build_forecast_payload(temp_sensor)
             if forecast_payload is None:
                 self.battery_forecast_data = None
-                _LOGGER.warning("🔋 Battery forecast returned no timeline data")
+                _LOGGER.debug("🔋 Battery forecast returned no timeline data")
                 return
 
             timeline_data = getattr(temp_sensor, "_timeline_data", None) or []

--- a/custom_components/oig_cloud/entities/battery_health_sensor.py
+++ b/custom_components/oig_cloud/entities/battery_health_sensor.py
@@ -96,6 +96,13 @@ class BatteryHealthTracker:
             f"BatteryHealthTracker initialized, nominal capacity: {nominal_capacity_kwh:.2f} kWh"
         )
 
+    def is_analysis_due(self, now: Optional[datetime] = None) -> bool:
+        """Return whether the expensive recorder scan should run again."""
+        if self._last_analysis is None:
+            return True
+        current_time = now or dt_util.now()
+        return current_time - self._last_analysis >= timedelta(hours=20)
+
     def _get_nominal_capacity_kwh(self) -> float:
         """Get nominal battery capacity from sensor, fallback to stored value."""
         if not self._hass:
@@ -244,8 +251,8 @@ class BatteryHealthTracker:
 
             self._last_analysis = dt_util.now()
 
+            await self.async_save_to_storage()
             if new_measurements:
-                await self.async_save_to_storage()
                 _LOGGER.info(f"Found {len(new_measurements)} new clean charging cycles")
 
             return new_measurements
@@ -1152,7 +1159,10 @@ class BatteryHealthSensor(CoordinatorEntityBase, SensorEntity):
         if not self._tracker:
             return
         await self._tracker.backfill_from_statistics()
-        await self._tracker.analyze_last_10_days()
+        if self._tracker.is_analysis_due():
+            await self._tracker.analyze_last_10_days()
+        else:
+            _LOGGER.debug("Skipping recent battery health recorder scan")
         self._refresh_entity_state()
         self.async_write_ha_state()
 

--- a/custom_components/oig_cloud/manifest.json
+++ b/custom_components/oig_cloud/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/psimsa/oig_cloud/issues",
   "requirements": ["numpy>=1.24.0", "paho-mqtt>=1.6.1"],
   "ssdp": [],
-  "version": "2.4.0",
+  "version": "2.4.1",
   "zeroconf": []
 }

--- a/custom_components/oig_cloud/sensors/SENSOR_TYPES_BOILER.py
+++ b/custom_components/oig_cloud/sensors/SENSOR_TYPES_BOILER.py
@@ -35,7 +35,7 @@ SENSOR_TYPES_BOILER: Dict[str, Dict[str, Any]] = {
     "boiler_day_w": {
         "name": "Boiler - Today Energy",
         "name_cs": "Bojler - Dnešní uložení",
-        "device_class": SensorDeviceClass.POWER,
+        "device_class": SensorDeviceClass.ENERGY,
         "unit_of_measurement": UnitOfEnergy.WATT_HOUR,
         "node_id": "boiler",
         "node_key": "w",

--- a/tests/test_boiler_sensor_metadata.py
+++ b/tests/test_boiler_sensor_metadata.py
@@ -1,0 +1,15 @@
+"""Regression tests for Home Assistant boiler sensor metadata."""
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfEnergy
+
+from custom_components.oig_cloud.sensors.SENSOR_TYPES_BOILER import SENSOR_TYPES_BOILER
+
+
+def test_boiler_day_counter_is_energy_not_power() -> None:
+    """The Wh day counter must remain valid as a utility-meter source."""
+    metadata = SENSOR_TYPES_BOILER["boiler_day_w"]
+
+    assert metadata["device_class"] is SensorDeviceClass.ENERGY
+    assert metadata["unit_of_measurement"] is UnitOfEnergy.WATT_HOUR
+    assert metadata["state_class"] is SensorStateClass.TOTAL_INCREASING

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,6 +1,7 @@
 """Tests for the OIG Cloud Data Update Coordinator."""
 
 import asyncio
+import logging
 
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -1976,7 +1977,7 @@ async def test_update_battery_forecast_with_timeline(monkeypatch, coordinator):
 
 
 @pytest.mark.asyncio
-async def test_update_battery_forecast_no_timeline(monkeypatch, coordinator):
+async def test_update_battery_forecast_no_timeline(monkeypatch, coordinator, caplog):
     class DummySensor:
         def __init__(self, *_a, **_k):
             self._timeline_data = None
@@ -1995,9 +1996,11 @@ async def test_update_battery_forecast_no_timeline(monkeypatch, coordinator):
         DummySensor,
     )
 
-    await coordinator._update_battery_forecast()
+    with caplog.at_level(logging.WARNING):
+        await coordinator._update_battery_forecast()
 
     assert coordinator.battery_forecast_data is None
+    assert "Battery forecast returned no timeline data" not in caplog.text
 
 
 def test_create_simple_battery_forecast_no_data(monkeypatch, coordinator):

--- a/tests/test_entities_battery_health_sensor.py
+++ b/tests/test_entities_battery_health_sensor.py
@@ -254,6 +254,48 @@ async def test_analyze_last_10_days_happy_path(monkeypatch):
     assert tracker._last_analysis is not None
 
 
+@pytest.mark.asyncio
+async def test_analyze_last_10_days_persists_empty_success(monkeypatch):
+    store = DummyStore()
+    monkeypatch.setattr(module, "Store", lambda *_a, **_k: store)
+    t0 = datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc)
+    hass = DummyHass(DummyStates({}))
+    tracker = module.BatteryHealthTracker(hass, "123", nominal_capacity_kwh=15.3)
+
+    class DummyInstance:
+        async def async_add_executor_job(self, _func, *_args, **_kwargs):
+            return {
+                "sensor.oig_123_batt_bat_c": [
+                    DummyState("10", t0),
+                    DummyState("20", t0 + timedelta(hours=1)),
+                ],
+                "sensor.oig_123_computed_batt_charge_energy_month": [
+                    DummyState("1000", t0),
+                    DummyState("1100", t0 + timedelta(hours=1)),
+                ],
+            }
+
+    monkeypatch.setattr(
+        "homeassistant.components.recorder.get_instance", lambda *_a, **_k: DummyInstance()
+    )
+
+    assert await tracker.analyze_last_10_days() == []
+    assert store.saved["last_analysis"] is not None
+
+
+def test_analysis_due_uses_last_successful_analysis(monkeypatch):
+    monkeypatch.setattr(module, "Store", DummyStore)
+    hass = DummyHass(DummyStates({}))
+    tracker = module.BatteryHealthTracker(hass, "123")
+    now = datetime(2025, 1, 2, 12, 0, tzinfo=timezone.utc)
+
+    assert tracker.is_analysis_due(now)
+    tracker._last_analysis = now - timedelta(hours=19)
+    assert not tracker.is_analysis_due(now)
+    tracker._last_analysis = now - timedelta(hours=21)
+    assert tracker.is_analysis_due(now)
+
+
 def test_find_monotonic_intervals_ignores_unknown(monkeypatch):
     monkeypatch.setattr(module, "Store", DummyStore)
     hass = DummyHass(DummyStates({}))
@@ -509,7 +551,9 @@ async def test_battery_health_sensor_remove_and_initial_analysis(monkeypatch):
         called["analyze"] += 1
 
     sensor._tracker = SimpleNamespace(
-        analyze_last_10_days=fake_analyze, backfill_from_statistics=fake_backfill
+        analyze_last_10_days=fake_analyze,
+        backfill_from_statistics=fake_backfill,
+        is_analysis_due=lambda: True,
     )
     sensor.async_write_ha_state = lambda *args, **kwargs: None
     sensor._daily_unsub = lambda: called.__setitem__("daily", called["daily"] + 1)
@@ -521,6 +565,41 @@ async def test_battery_health_sensor_remove_and_initial_analysis(monkeypatch):
     assert called["sleep"] == 1
     assert called["analyze"] == 1
     assert called["daily"] == 1
+
+
+@pytest.mark.asyncio
+async def test_initial_analysis_skips_recent_full_history_scan(monkeypatch):
+    monkeypatch.setattr(module, "Store", DummyStore)
+    hass = DummyHass(DummyStates({}))
+    coordinator = SimpleNamespace(
+        hass=hass, last_update_success=True, async_add_listener=lambda *_a, **_k: lambda: None
+    )
+    sensor = module.BatteryHealthSensor(
+        coordinator, "battery_health", SimpleNamespace(), {}, hass
+    )
+    sensor.hass = hass
+    called = {"analyze": 0, "backfill": 0}
+
+    async def fake_backfill():
+        called["backfill"] += 1
+
+    async def fake_analyze():
+        called["analyze"] += 1
+
+    sensor._tracker = SimpleNamespace(
+        analyze_last_10_days=fake_analyze,
+        backfill_from_statistics=fake_backfill,
+        is_analysis_due=lambda: False,
+    )
+    sensor.async_write_ha_state = lambda *args, **kwargs: None
+
+    async def fake_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(module.asyncio, "sleep", fake_sleep)
+    await sensor._initial_analysis()
+
+    assert called == {"analyze": 0, "backfill": 1}
 
 
 def test_battery_health_sensor_native_value_and_attrs(monkeypatch):

--- a/tests/test_load_profiles_more.py
+++ b/tests/test_load_profiles_more.py
@@ -120,3 +120,27 @@ def test_get_load_avg_sensors_valid(monkeypatch):
 
     result = load_profiles.get_load_avg_sensors(sensor)
     assert result["sensor.oig_123_load_avg_x"]["value"] == 100.0
+
+
+def test_get_load_avg_sensors_supports_unprefixed_entity_ids(monkeypatch):
+    sensor = DummySensor(
+        DummyHass({"sensor.load_avg_x": SimpleNamespace(state="125")})
+    )
+
+    class DummyStats:
+        data = {
+            "load_avg_x": {"time_range": (0, 24), "day_type": "weekday"},
+        }
+
+        @classmethod
+        def items(cls):
+            return cls.data.items()
+
+    monkeypatch.setattr(
+        "custom_components.oig_cloud.sensors.SENSOR_TYPES_STATISTICS.SENSOR_TYPES_STATISTICS",
+        DummyStats,
+        raising=False,
+    )
+
+    result = load_profiles.get_load_avg_sensors(sensor)
+    assert result["sensor.load_avg_x"]["value"] == 125.0


### PR DESCRIPTION
## Summary
- resolve canonical `sensor.load_avg_*` helpers with box-prefixed entities retaining priority
- persist successful battery-health scans even when no cycle is found
- skip duplicate full recorder scans for 20 hours after a successful analysis
- bump the integration version to 2.4.1 and document the fixes

## Verification
- 44 focused regression tests passed
- full suite: 4,836 passed, 27 skipped, coverage 91.28%
- 14 unrelated full-suite failures reproduced on an untouched `origin/main` worktree; 10 are order-dependent service-test failures and 4 fail standalone on `origin/main`
- Flake8 passed on changed Python and tests
- focused MyPy passed
- focused Pylint errors/fatals passed with 10.00/10
- Bandit passed
- `compileall`, manifest JSON validation, and `git diff --check` passed

## Live evidence
- Home Assistant exposes ten valid unprefixed `sensor.load_avg_*` helpers
- version 2.4.0 only looks for `sensor.oig_<box_id>_load_avg_*`, logging zero matches
- repeated startup analysis read about 2,088 SoC, 20,426 charge, and 40,711 discharge states because an empty successful scan did not persist `last_analysis`
