### PR TITLE
Fix frontend release artifact staging

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add dist/
+          git add -f -- dist/
           if git diff --staged --quiet; then
             echo "No changes to dist/, skipping commit."
           else

--- a/tests/test_build_frontend_workflow.py
+++ b/tests/test_build_frontend_workflow.py
@@ -1,0 +1,73 @@
+"""Behavioral regression tests for the frontend build workflow."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "build-frontend.yml"
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ("git", *args),
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_commit_step_pushes_ignored_frontend_dist(tmp_path: Path) -> None:
+    """A fresh ignored build output must still be committed and pushed."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["build"]["steps"]
+    commit_step = next(step for step in steps if step.get("name") == "Commit and push dist")
+
+    repo = tmp_path / "repo"
+    remote = tmp_path / "remote.git"
+    frontend = repo / commit_step["working-directory"]
+    frontend.mkdir(parents=True)
+    (repo / ".gitignore").write_text("dist/\n", encoding="utf-8")
+    (frontend / "package.json").write_text("{}\n", encoding="utf-8")
+
+    _git("init", "--bare", str(remote), cwd=tmp_path)
+    _git("init", "-b", "main", cwd=repo)
+    _git("config", "user.name", "Test User", cwd=repo)
+    _git("config", "user.email", "test@example.invalid", cwd=repo)
+    _git("add", ".gitignore", str(frontend.relative_to(repo) / "package.json"), cwd=repo)
+    _git("commit", "-m", "initial", cwd=repo)
+    _git("remote", "add", "origin", str(remote), cwd=repo)
+    _git("push", "-u", "origin", "main", cwd=repo)
+
+    built_file = frontend / "dist" / "index.html"
+    built_file.parent.mkdir()
+    built_file.write_text("release artifact\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    isolated_home = tmp_path / "home"
+    isolated_home.mkdir()
+    env["HOME"] = str(isolated_home)
+    result = subprocess.run(
+        ("bash", "-e", "-c", commit_step["run"]),
+        cwd=frontend,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    stored = _git(
+        "--git-dir",
+        str(remote),
+        "show",
+        "main:custom_components/oig_cloud/www_v2/dist/index.html",
+        cwd=tmp_path,
+    )
+    assert stored.stdout == "release artifact\n"


### PR DESCRIPTION
## Summary

- Fix the post-merge `Build Frontend` workflow failure caused by the repository-wide `dist/` ignore rule.
- Force-stage only `custom_components/oig_cloud/www_v2/dist/` from the step's fixed working directory; `--` terminates Git options.
- Add a behavioral regression that executes the real workflow shell step in an isolated temporary repository and verifies an ignored frontend artifact is committed and pushed to a local bare remote.

## Root cause

Origin run `31774101984` completed dependency installation and the frontend build, then failed in `Commit and push dist` because `git add dist/` rejected the ignored directory. The repository intentionally tracks this generated directory despite the global `dist/` ignore pattern.

## Validation

- TDD RED: regression failed with the exact `The following paths are ignored` error.
- TDD GREEN: focused regression passed.
- Full local CI wrapper: exit `0`.
- Python: `5,513 passed`, `29 skipped`; coverage `91%`.
- Frontend: `2,489 passed`; statements/lines `81.51%`, branches `80.83%`, functions `80.50%`.
- Hassfest: `1` integration, `0` invalid.
- Two consecutive all-files pre-commit runs: all nine hooks passed without rewrites.
- Gitleaks: no finding.
- Codex Security diff scan `04350976-0b43-4a43-84ae-439ada397d1a`: two reviewed surfaces, zero candidates/findings, complete coverage.

## Release impact

- No Home Assistant runtime or frontend source changes.
- Existing `v2.4.1` tag and GitHub draft remain unpublished while this PR runs origin CI.
- External `security/snyk (muriel2horak)` is explicitly waived by the operator for this release; all other repository and Sonar checks remain required.
